### PR TITLE
Fix article['body'] so it actually has content

### DIFF
--- a/lib/middleman-blog/feature.rb
+++ b/lib/middleman-blog/feature.rb
@@ -66,7 +66,7 @@ module Middleman
               data["url"] = article.gsub(app.views, "").split(".html").first + ".html"
 
               all_content = Tilt.new(article).render
-              data["body"] = all_content.gsub!(app.settings.blog_summary_separator, "")
+              data["body"] = all_content.gsub(app.settings.blog_summary_separator, "")
 
               sum = if data["raw"] =~ app.settings.blog_summary_separator
                 data["raw"].split(app.settings.blog_summary_separator).first


### PR DESCRIPTION
`all_content.gsub!` doesn't actually return anything, it only modifies the `all_content` object (at least on Ruby 1.9.2), so I changed the call to use simply `gsub` instead. Now I can use the full article body in listings.
