### PR TITLE
Blog articles' source can be in a different path pattern than their permalink

### DIFF
--- a/features/blog_sources.feature
+++ b/features/blog_sources.feature
@@ -1,0 +1,9 @@
+Feature: Flexible article sources
+  Scenario: Blog articles can live under a different structure than their permalink
+    Given the Server is running at "blog-sources-app"
+    When I go to "/2011/01/01/new-article.html"
+    Then I should see "/2011/01/01/new-article.html"
+    When I go to "/blog/2001-01-01-new-article.html"
+    Then I should see "Not Found"
+    When I go to "/"
+    Then I should see "/2011/01/01/new-article.html"

--- a/fixtures/blog-sources-app/config.rb
+++ b/fixtures/blog-sources-app/config.rb
@@ -1,0 +1,2 @@
+activate :blog
+set :blog_sources, ":year-:month-:day-:title.html"

--- a/fixtures/blog-sources-app/source/_article_template.erb
+++ b/fixtures/blog-sources-app/source/_article_template.erb
@@ -1,0 +1,1 @@
+<%= current_article.url %>

--- a/fixtures/blog-sources-app/source/blog/2011-01-01-new-article.html.markdown
+++ b/fixtures/blog-sources-app/source/blog/2011-01-01-new-article.html.markdown
@@ -1,0 +1,6 @@
+--- 
+title: "Newer Article"
+date: 01/01/2011
+---
+
+Newer Article Content

--- a/fixtures/blog-sources-app/source/index.html.erb
+++ b/fixtures/blog-sources-app/source/index.html.erb
@@ -1,0 +1,9 @@
+<% blog.articles[0...5].each_with_index do |article, i| %>
+  <article class="<%= (i == 0) ? 'first' : '' %>">
+    <h1><a href="<%= article.url %>"><%= article.title %></a> <span><%= article.date.strftime('%b %e %Y') %></span></h1>
+    
+    <%= article.summary %>
+    
+    <div class="more"><a href="<%= article.url %>">read on &raquo;</a></div>
+  </article>
+<% end %>

--- a/fixtures/blog-sources-app/source/layout.erb
+++ b/fixtures/blog-sources-app/source/layout.erb
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>

--- a/fixtures/indexes-app/config.rb
+++ b/fixtures/indexes-app/config.rb
@@ -1,2 +1,3 @@
 activate :blog
 activate :directory_indexes
+set :blog_sources, ":year/:month/:day/:title.html"

--- a/fixtures/preview-app/config.rb
+++ b/fixtures/preview-app/config.rb
@@ -1,1 +1,3 @@
 activate :blog
+set :blog_sources, ":year/:month/:day/:title.html"
+

--- a/fixtures/utf8ouch/config.rb
+++ b/fixtures/utf8ouch/config.rb
@@ -1,7 +1,5 @@
 activate :blog
-# set :blog_permalink, ":year/:month/:day/:title.html"
-# set :blog_summary_separator, /READMORE/
-# set :blog_summary_length, 500
+set :blog_sources, ":year/:month/:day/:title.html"
 
 page "/feed.xml", :layout => false
 


### PR DESCRIPTION
This introduces a `blog_sources` setting which gives the pattern of blog article sources - they'll be transformed into the pattern set in `blog_permalink` during build/preview. This allows authors to have a flat directory of articles but output a nested-directories style like Wordpress or Jekyll. This implements issue #15.
