### PR TITLE
Generate pages for tags if a blog_tag_template is specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 .mm-pid-*
 doc
 .yardoc
+build/

--- a/features/tags.feature
+++ b/features/tags.feature
@@ -1,0 +1,28 @@
+Feature: Tag pages
+  Scenario: Tag pages are accessible from preview server
+    Given the Server is running at "tags-app"
+    When I go to "/tags/foo.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should see "/2011-01-02-another-article.html"
+    Then I should see "Tag: foo"
+    When I go to "/tags/bar.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should not see "/2011-01-02-another-article.html"
+    Then I should see "Tag: bar"
+    
+  Scenario: Tag pages also get built
+    Given a successfully built app at "tags-app"
+    When I cd to "build"
+    Then the following files should exist:
+    | tags/foo.html |
+    | tags/bar.html |
+    Then the following files should not exist:
+    | tags.html |
+
+    And the file "tags/foo.html" should contain "Tag: foo"
+    And the file "tags/foo.html" should contain "/2011-01-01-new-article.html"
+    And the file "tags/foo.html" should contain "/2011-01-02-another-article.html"
+
+    And the file "tags/bar.html" should contain "Tag: bar"
+    And the file "tags/bar.html" should contain "/2011-01-01-new-article.html"
+    And the file "tags/bar.html" should not contain "/2011-01-02-another-article.html"

--- a/fixtures/tags-app/config.rb
+++ b/fixtures/tags-app/config.rb
@@ -1,0 +1,6 @@
+require "middleman-blog"
+activate :blog
+
+set :blog_sources, "blog/:year-:month-:day-:title.html"
+set :blog_permalink, "blog/:year-:month-:day-:title.html"
+set :blog_tag_template, "/tag.html"

--- a/fixtures/tags-app/source/blog/2011-01-01-new-article.html.markdown
+++ b/fixtures/tags-app/source/blog/2011-01-01-new-article.html.markdown
@@ -1,0 +1,7 @@
+--- 
+title: "Newer Article"
+date: 01/01/2011
+tags: foo, bar
+---
+
+Newer Article Content

--- a/fixtures/tags-app/source/blog/2011-01-02-another-article.html.markdown
+++ b/fixtures/tags-app/source/blog/2011-01-02-another-article.html.markdown
@@ -1,0 +1,8 @@
+--- 
+title: "Another Article"
+date: 01/01/2011
+tags:
+  - foo
+---
+
+Another Article Content

--- a/fixtures/tags-app/source/index.html.erb
+++ b/fixtures/tags-app/source/index.html.erb
@@ -1,0 +1,3 @@
+ <% blog.articles[0...12].each do |article| %>
+      <li><a href="<%= article.url %>"><%= article.title %></a> <time><%= article.date.strftime('%b %e') %></time></li>
+    <% end %>

--- a/fixtures/tags-app/source/layout.erb
+++ b/fixtures/tags-app/source/layout.erb
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>

--- a/fixtures/tags-app/source/tag.html.erb
+++ b/fixtures/tags-app/source/tag.html.erb
@@ -1,0 +1,7 @@
+Tag: <%= @tag %>
+
+<% if @articles %>
+  <% @articles[0...12].each do |article| %>
+    <li><a href="<%= article.url %>"><%= article.title %></a> <time><%= article.date.strftime('%b %e') %></time></li>
+  <% end %>
+<% end %>

--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -56,6 +56,18 @@ module Middleman
 
           app.ready do
             puts "== Blog: #{blog_permalink}" unless build?
+
+            # Set up tag pages if the tag template has been specified
+            if defined? blog_tag_template
+              page blog_tag_template, :ignore => true
+
+              blog.tags.each do |tag, articles|
+                page tag_path(tag), :proxy => blog_tag_template do
+                  @tag = tag
+                  @articles = articles
+                end
+              end
+            end
           end
         end
         alias :included :registered
@@ -222,6 +234,10 @@ module Middleman
 
         def current_article
           blog.article(current_page.path)
+        end
+
+        def tag_path(tag)
+          blog_taglink.sub(':tag', tag.parameterize)
         end
       end
     end


### PR DESCRIPTION
When `blog_tag_template` is set, a proxy page will be created for each tag, with `@tag` and `@articles` set to the tag and list of articles with that tag, respectively. This fixes issue #17.
