### PR TITLE
Generate date-based calendar pages

### DIFF
--- a/features/calendar.feature
+++ b/features/calendar.feature
@@ -1,0 +1,30 @@
+Feature: Calendar pages
+  Scenario: Calendar pages are accessible from preview server
+    Given the Server is running at "calendar-app"
+    When I go to "/2011.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should see "/2011-01-02-another-article.html"
+    Then I should see "Year: '2011'"
+    Then I should see "Month: ''"
+    Then I should see "Day: ''"
+
+    When I go to "/2011/01.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should see "/2011-01-02-another-article.html"
+    Then I should see "Year: '2011'"
+    Then I should see "Month: '1'"
+    Then I should see "Day: ''"
+
+    When I go to "/2011/01/01.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should not see "/2011-01-02-another-article.html"
+    Then I should see "Year: '2011'"
+    Then I should see "Month: '1'"
+    Then I should see "Day: '1'"
+
+    When I go to "/2011/01/02.html"
+    Then I should not see "/2011-01-01-new-article.html"
+    Then I should see "/2011-01-02-another-article.html"
+    Then I should see "Year: '2011'"
+    Then I should see "Month: '1'"
+    Then I should see "Day: '2'"

--- a/fixtures/calendar-app/config.rb
+++ b/fixtures/calendar-app/config.rb
@@ -1,0 +1,5 @@
+activate :blog
+
+set :blog_sources, "blog/:year-:month-:day-:title.html"
+set :blog_permalink, "blog/:year-:month-:day-:title.html"
+set :blog_calendar_template, 'calendar.html'

--- a/fixtures/calendar-app/source/blog/2011-01-01-new-article.html.markdown
+++ b/fixtures/calendar-app/source/blog/2011-01-01-new-article.html.markdown
@@ -1,0 +1,7 @@
+--- 
+title: "Newer Article"
+date: 01/01/2011
+tags: foo, bar
+---
+
+Newer Article Content

--- a/fixtures/calendar-app/source/blog/2011-01-02-another-article.html.markdown
+++ b/fixtures/calendar-app/source/blog/2011-01-02-another-article.html.markdown
@@ -1,0 +1,8 @@
+--- 
+title: "Another Article"
+date: 01/02/2011
+tags:
+  - foo
+---
+
+Another Article Content

--- a/fixtures/calendar-app/source/calendar.html.erb
+++ b/fixtures/calendar-app/source/calendar.html.erb
@@ -1,0 +1,13 @@
+Year: '<%= @year %>'
+Month: '<%= @month %>'
+Day: '<%= @day %>'
+
+<% @articles[0...5].each_with_index do |article, i| %>
+  <article class="<%= (i == 0) ? 'first' : '' %>">
+    <h1><a href="<%= article.url %>"><%= article.title %></a> <span><%= article.date.strftime('%b %e %Y') %></span></h1>
+    
+    <%= article.summary %>
+    
+    <div class="more"><a href="<%= article.url %>">read on &raquo;</a></div>
+  </article>
+<% end %>

--- a/fixtures/calendar-app/source/index.html.erb
+++ b/fixtures/calendar-app/source/index.html.erb
@@ -1,0 +1,3 @@
+ <% blog.articles[0...12].each do |article| %>
+      <li><a href="<%= article.url %>"><%= article.title %></a> <time><%= article.date.strftime('%b %e') %></time></li>
+    <% end %>

--- a/fixtures/calendar-app/source/layout.erb
+++ b/fixtures/calendar-app/source/layout.erb
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>


### PR DESCRIPTION
Same idea as the tag pages - either specify `:blog_calendar_template` or `:blog_year_template`, `:blog_month_template`, and `:blog_day_template` individually, and the extension will generate date-based calendar pages for year, month, and day, passing in `@year`, `@month`, `@day`, and `@articles` variables for use in the template. Users may also independently set the link pattern for year, month, and day pages. This fixes issue #14.
