### PR TITLE
Get blog template to show up in middleman CLI

### DIFF
--- a/lib/middleman-blog.rb
+++ b/lib/middleman-blog.rb
@@ -1,8 +1,8 @@
 require "middleman-core"
 
+require "middleman-blog/template"
+
 ::Middleman::Extensions.register(:blog, ">= 3.0.0.beta.2") do
   require "middleman-blog/extension"
-  require "middleman-blog/template"
-  
   ::Middleman::Extensions::Blog
 end


### PR DESCRIPTION
Turns out the problem was that the template bit was being required inside the `register` block, which is only called after the extension is activated, which is a bit of a catch-22 when you haven't built a project yet. This depends on pull request middleman/middleman#310 to work for me, and should fix issue #11.
