### PR TITLE
Add an 'article' command to the CLI

### DIFF
--- a/features/article_cli.feature
+++ b/features/article_cli.feature
@@ -1,0 +1,7 @@
+Feature: New article CLI command
+ Scenario: Create a new blog article with the CLI
+   Given a fixture app "blog-sources-app"
+   And I run `middleman article "My New Article" --date 2012-03-17`
+   Then the exit status should be 0
+   Then the following files should exist:
+     | source/2012-03-17-my-new-article.html.markdown |

--- a/lib/middleman-blog.rb
+++ b/lib/middleman-blog.rb
@@ -1,7 +1,8 @@
 require "middleman-core"
 
 require "middleman-blog/template"
-
+require "middleman-blog/commands/article"
+  
 ::Middleman::Extensions.register(:blog, ">= 3.0.0.beta.2") do
   require "middleman-blog/extension"
   ::Middleman::Extensions::Blog

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -1,0 +1,46 @@
+require 'middleman-core/cli'
+require 'date'
+
+module Middleman
+  module Cli
+    class Article < Thor
+      include Thor::Actions
+
+      check_unknown_options!
+
+      namespace :article
+
+      # Template files are relative to this file
+      # @return [String]
+      def self.source_root
+        File.dirname(__FILE__)
+      end
+
+      desc "article TITLE", "Create a new blog article"
+      method_option "date",
+        :aliases => "-d",
+        :desc => "The date to create the post with (defaults to now)"      
+      def article(title)
+        shared_instance = ::Middleman.server.inst
+
+        # This only exists when the config.rb sets it!
+        if shared_instance.respond_to? :blog_sources
+          @title = title
+          @slug = title.parameterize
+          @date = options[:date] ? DateTime.parse(options[:date]) : DateTime.now
+
+          article_path = shared_instance.blog_sources.
+            sub(':year', @date.year.to_s).
+            sub(':month', @date.month.to_s.rjust(2,'0')).
+            sub(':day', @date.day.to_s.rjust(2,'0')).
+            sub(':title', @slug)
+
+          template "article.tt", File.join(shared_instance.source_dir, article_path + shared_instance.blog_default_extension)
+        else
+          raise Thor::Error.new "You need to activate the blog extension in config.rb before you can create an article"
+        end
+      end
+    end
+  end
+end
+

--- a/lib/middleman-blog/commands/article.tt
+++ b/lib/middleman-blog/commands/article.tt
@@ -1,0 +1,6 @@
+---
+title: <%= @title %>
+date: <%= @date.strftime('%F %R %Z') %>
+tags:
+---
+

--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -14,6 +14,7 @@ module Middleman
           app.set :blog_year_link, ":year.html"
           app.set :blog_month_link, ":year/:month.html"
           app.set :blog_day_link, ":year/:month/:day.html"
+          app.set :blog_default_extension, ".markdown"
             
           app.send :include, InstanceMethods
 


### PR DESCRIPTION
This allows you to create new articles by running:

```
middleman article "My New Post"
```

Which uses your `blog_sources` setting to properly create a new post with the right date, frontmatter, and slug. It also introduces a `blog_default_extension` so if people don't want to use markdown the `article` command will produce files with their preferred extension. This resolves #13.
