### PR TITLE
Figure out date from filename

### DIFF
--- a/features/filename_date.feature
+++ b/features/filename_date.feature
@@ -1,0 +1,9 @@
+Feature: Derive article date from its source filename
+  Scenario: Posts with dates in filenames and optionally frontmatter
+    Given the Server is running at "filename-date-app"
+    When I go to "/2011/01/01/new-article.html"
+    Then I should see "Date: 2011-01-01T00:00:00"
+    When I go to "/2011/01/03/filename-and-frontmatter.html"
+    Then I should see "Date: 2011-01-03T10:15:00"
+
+

--- a/fixtures/filename-date-app/config.rb
+++ b/fixtures/filename-date-app/config.rb
@@ -1,0 +1,1 @@
+activate :blog

--- a/fixtures/filename-date-app/source/2011-01-01-new-article.html.markdown
+++ b/fixtures/filename-date-app/source/2011-01-01-new-article.html.markdown
@@ -1,0 +1,5 @@
+--- 
+title: "Newer Article"
+---
+
+Newer Article Content

--- a/fixtures/filename-date-app/source/2011-01-03-filename-and-frontmatter.html.markdown
+++ b/fixtures/filename-date-app/source/2011-01-03-filename-and-frontmatter.html.markdown
@@ -1,0 +1,6 @@
+--- 
+title: "Filename and frontmatter"
+date: 2011-01-03 10:15AM PST
+---
+
+Newer Article Content

--- a/fixtures/filename-date-app/source/layout.erb
+++ b/fixtures/filename-date-app/source/layout.erb
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+      <p>Date: <%= current_article.date %></p>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>

--- a/fixtures/tags-app/source/blog/2011-01-02-another-article.html.markdown
+++ b/fixtures/tags-app/source/blog/2011-01-02-another-article.html.markdown
@@ -1,6 +1,6 @@
 --- 
 title: "Another Article"
-date: 2011-01-01
+date: 2011-01-02
 tags:
   - foo
 ---


### PR DESCRIPTION
Pretty much what it says on the tin. This resolves issue #26 by not requiring users to specify a date in both the filename and frontmatter of blog posts. I think it also makes posts completely Jekyll-compatible (both ways - Jekyll importers should produce Middleman-compatible files).
