### PR TITLE
Tighten up matcher for blog article sources

### DIFF
--- a/features/article_cli.feature
+++ b/features/article_cli.feature
@@ -4,4 +4,4 @@ Feature: New article CLI command
    And I run `middleman article "My New Article" --date 2012-03-17`
    Then the exit status should be 0
    Then the following files should exist:
-     | source/2012-03-17-my-new-article.html.markdown |
+     | source/blog/2012-03-17-my-new-article.html.markdown |

--- a/fixtures/blog-sources-app/config.rb
+++ b/fixtures/blog-sources-app/config.rb
@@ -1,2 +1,2 @@
 activate :blog
-set :blog_sources, ":year-:month-:day-:title.html"
+set :blog_sources, "blog/:year-:month-:day-:title.html"


### PR DESCRIPTION
Before, the matcher that we generated would match all kinds of paths that had the blog article pattern anywhere within them - this change locks it down so only paths exactly matching the `blog_sources` setting get matched.
