### PR TITLE
Simplify registration and avoid extra sitemap rebuild

### DIFF
--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -33,35 +33,31 @@ module Middleman
             set :blog_day_template, blog_calendar_template
           end
 
-          app.ready do
+          sitemap.register_resource_list_manipulator(
+            :blog_articles,
+            blog,
+            false
+          )
+
+          if defined? blog_tag_template
+            ignore blog_tag_template
+
             sitemap.register_resource_list_manipulator(
-              :blog_articles,
-              blog,
+              :blog_tags,
+              TagPages.new(self),
               false
             )
+          end
 
-            if defined? blog_tag_template
-              ignore blog_tag_template
+          if defined? blog_year_template || 
+             defined? blog_month_template || 
+             defined? blog_day_template
 
-              sitemap.register_resource_list_manipulator(
-                :blog_tags,
-                TagPages.new(self),
-                false
-              )
-            end
-
-            if defined? blog_year_template || 
-               defined? blog_month_template || 
-               defined? blog_day_template
-
-              sitemap.register_resource_list_manipulator(
-                :blog_calendar,
-                CalendarPages.new(self),
-                false
-              )
-            end
-
-            sitemap.rebuild_resource_list!(:registered_new)
+            sitemap.register_resource_list_manipulator(
+              :blog_calendar,
+              CalendarPages.new(self),
+              false
+            )
           end
         end
       end


### PR DESCRIPTION
The diff looks weird, but really I just removed the extra `app.ready` callback because it was unnecessary, and then got rid of the sitemap rebuild because other things make sure the sitemap is rebuild before `ready`.
