### PR TITLE
Use the new add_metadata method on Resource to simplify calendar and tag pages

### DIFF
--- a/lib/middleman-blog/calendar_pages.rb
+++ b/lib/middleman-blog/calendar_pages.rb
@@ -25,13 +25,9 @@ module Middleman
             )
             p.proxy_to(@app.blog.year_template)
 
-            set_locals_year = Proc.new do
+            p.add_metadata do
               @year = year
               @articles = year_articles
-            end
-
-            @app.sitemap.provides_metadata_for_path path, :blog_calendar do |path|
-              { :blocks => set_locals_year }
             end
 
             new_resources << p
@@ -49,14 +45,10 @@ module Middleman
               )
               p.proxy_to(@app.blog.month_template)
 
-              set_locals_month = Proc.new do
+              p.add_metadata do
                 @year = year
                 @month = month
                 @articles = month_articles
-              end
-
-              @app.sitemap.provides_metadata_for_path path, :blog_calendar do |path|
-                { :blocks => [ set_locals_month ] }
               end
 
               new_resources << p
@@ -73,15 +65,11 @@ module Middleman
                 )
                 p.proxy_to(@app.blog.month_template)
 
-                set_locals_day = Proc.new do
+                p.add_metadata do
                   @year = year
                   @month = month
                   @day = day
                   @articles = day_articles
-                end
-
-                @app.sitemap.provides_metadata_for_path path, :blog_calendar do |path|
-                  { :blocks => [ set_locals_day ] }
                 end
 
                 new_resources << p

--- a/lib/middleman-blog/tag_pages.rb
+++ b/lib/middleman-blog/tag_pages.rb
@@ -20,15 +20,9 @@ module Middleman
           )
           p.proxy_to(@app.blog.tag_template)
 
-          set_locals = Proc.new do
+          p.add_metadata do
             @tag = tag
             @articles = articles
-          end
-
-          # TODO: how to keep from adding duplicates here?
-          # How could we better set locals?
-          @app.sitemap.provides_metadata_for_path path, :blog_tags do |path|
-            { :blocks => [ set_locals ] }
           end
 
           p


### PR DESCRIPTION
This ends up just being a more efficient way to get the right metadata to the right pages when the pages are being created by a manipulator.
