### PR TITLE
Add a blog.path option

### DIFF
--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -2,6 +2,7 @@ module Middleman
   module Blog
     class Options
       KEYS = [
+        :prefix,
         :permalink,
         :sources,
         :taglink,
@@ -60,6 +61,17 @@ module Middleman
           options.year_template  ||= options.calendar_template
           options.month_template ||= options.calendar_template
           options.day_template   ||= options.calendar_template
+        end
+
+        # If "prefix" option is specified, all other paths are relative to it.
+        if options.prefix
+          options.prefix = "/#{options.prefix}" unless options.prefix.start_with? '/'
+          options.permalink = File.join(options.prefix, options.permalink)
+          options.sources = File.join(options.prefix, options.sources)
+          options.taglink = File.join(options.prefix, options.taglink)
+          options.year_link = File.join(options.prefix, options.year_link)
+          options.month_link = File.join(options.prefix, options.month_link)
+          options.day_link = File.join(options.prefix, options.day_link)
         end
 
         app.after_configuration do


### PR DESCRIPTION
Add a `blog.path` option to make setting all the path options easier. `blog.path` defaults to nil, but if set will be prepended to all the paths you provide (or the defaults) in order to put your blog in a subdirectory. For example, my configs went from:

``` ruby
activate :blog do |blog|
  blog.permalink = "/blog/:year/:month/:day/:title.html"
  blog.sources = "blog/:year-:month-:day-:title.html"
  blog.taglink = "/blog/category/:tag.html"
  blog.layout = "article"
  blog.summary_separator = /(<!--more-->)/
  blog.summary_length = nil
  blog.year_link = "/blog/:year.html"
  blog.month_link = "/blog/:year/:month.html"
  blog.day_link = "/blog/:year/:month/:day.html"

  blog.tag_template = "blog/tag.html"
  blog.calendar_template = "blog/calendar.html"
end
```

to:

``` ruby
activate :blog do |blog|
  blog.path = "blog"
  blog.taglink = "/category/:tag.html"
  blog.layout = "article"
  blog.summary_separator = /(<!--more-->)/
  blog.summary_length = nil

  blog.tag_template = "blog/tag.html"
  blog.calendar_template = "blog/calendar.html"
end
```
