### PR TITLE
Correct copy/paste error causing day calendar to use the month template.

### DIFF
--- a/lib/middleman-blog/calendar_pages.rb
+++ b/lib/middleman-blog/calendar_pages.rb
@@ -63,7 +63,7 @@ module Middleman
                   @app.sitemap,
                   path
                 )
-                p.proxy_to(@app.blog.options.month_template)
+                p.proxy_to(@app.blog.options.day_template)
 
                 p.add_metadata do
                   @year = year


### PR DESCRIPTION
The daily calendar uses the month template because the code was copied and not completely updated.
