### PR TITLE
Allow articles to have their own layout set in the YAML front matter

### DIFF
--- a/features/layouts.feature
+++ b/features/layouts.feature
@@ -1,0 +1,21 @@
+Feature: Layouts
+  Background:
+    Given the Server is running at "layouts-app"
+  Scenario: The layout of a blog entry can be set in its front matter.
+    When I go to "/2011/01/01/first-article.html"
+    Then I should see "First Alternative Layout"
+    And I should see "First Article"
+    When I go to "/2011/01/01/second-article.html"
+    Then I should see "Second Alternative Layout"
+    And I should see "Second Article"
+    When I go to "/2011/01/01/third-article.html"
+    Then I should see "Third Alternative Layout"
+    And I should see "Third Article"
+  Scenario: The default blog layout is used if none is set in front matter.
+    When I go to "/2011/01/02/article-in-normal-layout.html"
+    Then I should see "Default Layout"
+    And I should see "New Article"
+  Scenario: Do not use a layout for the article if set to false in front matter.
+    When I go to "/2011/01/03/article-without-layout.html"
+    Then I should not see "Default Layout"
+    And I should see "Article Content"

--- a/fixtures/layouts-app/config.rb
+++ b/fixtures/layouts-app/config.rb
@@ -1,0 +1,5 @@
+activate :blog do |blog|
+  blog.sources = ":year/:month/:day/:title.html"
+end
+
+require "middleman-more"

--- a/fixtures/layouts-app/source/2011/01/01/first-article.html.markdown
+++ b/fixtures/layouts-app/source/2011/01/01/first-article.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "First Article"
+date: 2011-01-01
+layout: first
+---
+
+First Article Content

--- a/fixtures/layouts-app/source/2011/01/01/second-article.html.markdown
+++ b/fixtures/layouts-app/source/2011/01/01/second-article.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "Second Article"
+date: 2011-01-01
+layout: second
+---
+
+Second Article Content

--- a/fixtures/layouts-app/source/2011/01/01/third-article.html.markdown
+++ b/fixtures/layouts-app/source/2011/01/01/third-article.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "Third Article"
+date: 2011-01-01
+layout: !ruby/symbol third
+---
+
+Third Article Content

--- a/fixtures/layouts-app/source/2011/01/02/article-in-normal-layout.markdown
+++ b/fixtures/layouts-app/source/2011/01/02/article-in-normal-layout.markdown
@@ -1,0 +1,6 @@
+---
+title: "New Article"
+date: 2011-01-02
+---
+
+New Article Content

--- a/fixtures/layouts-app/source/2011/01/03/article-without-layout.markdown
+++ b/fixtures/layouts-app/source/2011/01/03/article-without-layout.markdown
@@ -1,0 +1,7 @@
+---
+title: "Article Without Layout"
+date: 2011-01-03
+layout: false
+---
+
+Article Content

--- a/fixtures/layouts-app/source/layouts/first.html.erb
+++ b/fixtures/layouts-app/source/layouts/first.html.erb
@@ -1,0 +1,2 @@
+<h1>First Alternative Layout</h1>
+<%= yield %>

--- a/fixtures/layouts-app/source/layouts/layout.erb
+++ b/fixtures/layouts-app/source/layouts/layout.erb
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Default Layout</h1>
+    <%= yield %>
+  </body>
+</html>

--- a/fixtures/layouts-app/source/layouts/second.html.erb
+++ b/fixtures/layouts-app/source/layouts/second.html.erb
@@ -1,0 +1,2 @@
+<h1>Second Alternative Layout</h1>
+<%= yield %>

--- a/fixtures/layouts-app/source/layouts/third.html.erb
+++ b/fixtures/layouts-app/source/layouts/third.html.erb
@@ -1,0 +1,2 @@
+<h1>Third Alternative Layout</h1>
+<%= yield %>

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -11,7 +11,13 @@ module Middleman
       # Render this resource
       # @return [String]
       def render(opts={}, locs={}, &block)
-        opts[:layout] = app.blog.options.layout if opts[:layout].nil?
+        if opts[:layout].nil?
+          if metadata[:options] && !metadata[:options][:layout].nil?
+            opts[:layout] = metadata[:options][:layout]
+          end
+          opts[:layout] = app.blog.options.layout if opts[:layout].nil?
+          opts[:layout] = opts[:layout].to_s if opts[:layout].is_a? Symbol
+        end
 
         content = super(opts, locs, &block)
 


### PR DESCRIPTION
As per issue #55, here's an addition allowing articles to use a different layout, if set in its YAML front matter.
