### PR TITLE
Allow articles to set "published: false"

### DIFF
--- a/features/published.feature
+++ b/features/published.feature
@@ -1,0 +1,33 @@
+Feature: Unpublished blog articles
+  Scenario: Unpublished articles show up in the preview server
+    Given the Server is running at "published-app"
+    When I go to "/2011/01/01/new-article.html"
+    Then I should see "Newer Article Content"
+    When I go to "/2012/06/19/draft-article.html"
+    Then I should see "This is a draft"
+    When I go to "/2012/06/19/draft-article/example.txt"
+    Then I should see "Example Text"
+
+  Scenario: Unpublished articles don't show up when the environment is not :development
+    Given a fixture app "published-app"
+    And a file named "config.rb" with:
+      """
+      set :environment, :production
+      activate :blog do |blog|
+        blog.sources = "blog/:year-:month-:day-:title.html"
+      end
+      """
+    Given the Server is running at "published-app"
+    When I go to "/2012/06/19/draft-article.html"
+    Then I should see "Not Found"
+    When I go to "/2012/06/19/draft-article/example.txt"
+    Then I should see "Not Found"
+
+  Scenario: Unpublished articles don't get built
+    Given a successfully built app at "published-app"
+    When I cd to "build"
+    Then the following files should not exist:
+      | 2012/06/19/draft-article.html        |
+      | 2012/06/19/draft-article/example.txt |
+    Then the following files should exist:
+      | 2011/01/01/new-article.html          |

--- a/fixtures/published-app/config.rb
+++ b/fixtures/published-app/config.rb
@@ -1,0 +1,3 @@
+activate :blog do |blog|
+  blog.sources = "blog/:year-:month-:day-:title.html"
+end

--- a/fixtures/published-app/source/_article_template.erb
+++ b/fixtures/published-app/source/_article_template.erb
@@ -1,0 +1,1 @@
+<%= current_article.url %>

--- a/fixtures/published-app/source/blog/2011-01-01-new-article.html.markdown
+++ b/fixtures/published-app/source/blog/2011-01-01-new-article.html.markdown
@@ -1,0 +1,6 @@
+--- 
+title: "Newer Article"
+date: 2011-01-01
+---
+
+Newer Article Content

--- a/fixtures/published-app/source/blog/2012-06-19-draft-article.html.markdown
+++ b/fixtures/published-app/source/blog/2012-06-19-draft-article.html.markdown
@@ -1,0 +1,7 @@
+--- 
+title: "Draft Article"
+date: 2012-06-19
+published: false
+---
+
+This is a draft

--- a/fixtures/published-app/source/blog/2012-06-19-draft-article/example.txt
+++ b/fixtures/published-app/source/blog/2012-06-19-draft-article/example.txt
@@ -1,0 +1,1 @@
+Example Text

--- a/fixtures/published-app/source/index.html.erb
+++ b/fixtures/published-app/source/index.html.erb
@@ -1,0 +1,9 @@
+<% blog.articles[0...5].each_with_index do |article, i| %>
+  <article class="<%= (i == 0) ? 'first' : '' %>">
+    <h1><a href="<%= article.url %>"><%= article.title %></a> <span><%= article.date.strftime('%b %e %Y') %></span></h1>
+    
+    <%= article.summary %>
+    
+    <div class="more"><a href="<%= article.url %>">read on &raquo;</a></div>
+  </article>
+<% end %>

--- a/fixtures/published-app/source/layout.erb
+++ b/fixtures/published-app/source/layout.erb
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -26,6 +26,12 @@ module Middleman
         data["title"]
       end
 
+      # Whether or not this article has been published
+      # @return [Boolean]
+      def published?
+        data["published"] != false
+      end
+
       # The body of this article, in HTML. This is for
       # things like RSS feeds or lists of articles - individual
       # articles will automatically be rendered from their

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -87,11 +87,15 @@ module Middleman
       # @return [void]
       def manipulate_resource_list(resources)
         @_articles = []
+        used_resources = []
 
         resources.each do |resource|
           if resource.path =~ path_matcher
             resource.extend BlogArticle
             
+            # Skip articles that have "published: false"
+            next unless @app.environment == :development || resource.published?
+
             # compute output path:
             #   substitute date parts to path pattern
             resource.destination_path = options.permalink.
@@ -116,6 +120,9 @@ module Middleman
             article = @app.sitemap.find_resource_by_path(article_path)
             raise "Article for #{resource.path} not found" if article.nil?
 
+            # Skip files that belong to articles that have "published: false"
+            next unless @app.environment == :development || article.published?
+
             # The subdir path is the article path with the index file name
             # or file extension stripped off.
             resource.destination_path = options.permalink.
@@ -127,7 +134,11 @@ module Middleman
 
             resource.destination_path = Middleman::Util.normalize_path(resource.destination_path)
           end
+
+          used_resources << resource
         end
+        
+        used_resources
       end
     end
   end


### PR DESCRIPTION
Setting `published: false` in frontmatter will make an article show up in preview but not in build/production. You can use this to keep drafts of posts checked in without showing them until you're ready. Inspired by the same feature in Jeckyll.
