### PR TITLE
Create summary from source instead of output

### DIFF
--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -9,6 +9,7 @@ module Middleman
         :layout,
         :summary_separator,
         :summary_length,
+        :summary_generator,
         :year_link,
         :month_link,
         :day_link,


### PR DESCRIPTION
The old way of generating an article summary by splitting at an empty
line could result in unclosed html tags. This patch avoids that in many
cases, by counting words and splitting on the source file instead of the
rendered output, and then rendering the summary separately.
