### PR TITLE
Absolute tag links

### DIFF
--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -46,7 +46,7 @@ module Middleman
         
         options.permalink         ||= "/:year/:month/:day/:title.html"
         options.sources           ||= ":year-:month-:day-:title.html"
-        options.taglink           ||= "tags/:tag.html"
+        options.taglink           ||= "/tags/:tag.html"
         options.layout            ||= "layout"
         options.summary_separator ||= /(READMORE)/
         options.summary_length    ||= 250


### PR DESCRIPTION
Is it by design that the tag_path helper generates a path relative to the current page? Seemed sort of broken to me, changed it.
