### PR TITLE
Default templates use correct articles, fixes #77

### DIFF
--- a/features/paginate.feature
+++ b/features/paginate.feature
@@ -65,8 +65,27 @@ Feature: Pagination
     Then I should see "/2011-02-01-test-article.html"
     Then I should see "/2011-02-02-test-article.html"
 
+    When I go to "/2011/01.html"
+    Then I should see "Paginate: false"
+    Then I should see "Article Count: 5"
+    Then I should see "/2011-01-01-test-article.html"
+    Then I should see "/2011-01-02-test-article.html"
+    Then I should see "/2011-01-03-test-article.html"
+    Then I should see "/2011-01-04-test-article.html"
+    Then I should see "/2011-01-05-test-article.html"
+    Then I should not see "/2011-02-01-test-article.html"
+    Then I should not see "/2011-02-02-test-article.html"
+
     When I go to "/2011/page/2.html"
     Then I should see "File Not Found"
+
+    When I go to "/tags/foo.html"
+    Then I should see "Paginate: false"
+    Then I should see "Article Count: 2"
+    Then I should not see "/2011-02-02-test-article.html"
+    Then I should not see "/2011-02-01-test-article.html"
+    Then I should see "/2011-01-02-test-article.html"
+    Then I should see "/2011-01-01-test-article.html"
 
     When I go to "/tags/bar.html"
     Then I should see "Paginate: false"

--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -192,7 +192,10 @@ module Middleman
       # @return [Array<Middleman::Sitemap::Resource>]
       def page_articles
         limit = (current_resource.metadata[:page]["per_page"] || 0) - 1
-        blog.articles[0..limit]
+
+        # "articles" local variable is populated by Calendar and Tag page generators
+        # If it's not set then use the complete list of articles
+        (current_resource.metadata[:locals]["articles"] || blog.articles)[0..limit]
       end
     end
   end


### PR DESCRIPTION
Calendar and Tag pages set the `articles` local but `page_articles` was
ignoring this when `blog.paginate = false`.
