### PR TITLE
Ensure article summary runs thru all template handlers

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -72,8 +72,16 @@ module Middleman
 
           md   = metadata.dup
           locs = md[:locals]
-          opts = md[:options].merge({:template_body => summary_source})
-          app.render_individual_file(source_file, locs, opts)
+          opts = md[:options]
+
+          file_path = source_file
+          content = summary_source
+          while ::Tilt[file_path]
+            opts[:template_body] = content
+            content = app.render_individual_file(file_path, locs, opts)
+            file_path = File.basename(file_path, File.extname(file_path))
+          end
+          content
         end
       end
 


### PR DESCRIPTION
Previously an article's summary only ran thru the first template handler. This ensures it runs thru all handlers so you get a correct summary when you have something like hello.markdown.erb
