### PR TITLE
Reform how we generate blog article summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 3.2.0
 ====
 
+* The `summary` method on articles is now HTML-aware, and can be provided with
+  a different summary length or ellipsis string: `summary(1000, '&hellip;')`
 * The `summary_generator` option now recieves the rendered article (without
   layout) instead of the template source.
 * Set `summary_length` to false to always use the full article as a summary.

--- a/lib/middleman-blog/truncate_html.rb
+++ b/lib/middleman-blog/truncate_html.rb
@@ -1,0 +1,49 @@
+require "nokogiri"
+
+# Taken and modified from http://madebydna.com/all/code/2010/06/04/ruby-helper-to-cleanly-truncate-html.html
+# MIT license
+module TruncateHTML
+  def self.truncate_html(text, max_length, ellipsis = "...")
+    ellipsis_length = ellipsis.length     
+    doc = Nokogiri::HTML::DocumentFragment.parse text
+    content_length = doc.inner_text.length
+    actual_length = max_length - ellipsis_length
+    if content_length > actual_length 
+      doc.truncate(actual_length, ellipsis).inner_html
+    else
+      text
+    end
+  end
+end
+
+module NokogiriTruncator
+  module NodeWithChildren
+    def truncate(max_length, ellipsis)
+      return self if inner_text.length <= max_length
+      truncated_node = self.dup
+      truncated_node.children.remove
+
+      self.children.each do |node|
+        remaining_length = max_length - truncated_node.inner_text.length
+        break if remaining_length <= 0
+        truncated_node.add_child node.truncate(remaining_length, ellipsis)
+      end
+      truncated_node
+    end
+  end
+
+  module TextNode
+    def truncate(max_length, ellipsis)
+      # Don't break in the middle of a word
+      trimmed_content = content.match(/(.{1,#{max_length}}[\w]*)/m).to_s
+      trimmed_content << ellipsis if trimmed_content.length < content.length
+
+      Nokogiri::XML::Text.new(trimmed_content, parent)
+    end
+  end
+
+end
+
+Nokogiri::HTML::DocumentFragment.send(:include, NokogiriTruncator::NodeWithChildren)
+Nokogiri::XML::Element.send(:include, NokogiriTruncator::NodeWithChildren)
+Nokogiri::XML::Text.send(:include, NokogiriTruncator::TextNode)

--- a/middleman-blog.gemspec
+++ b/middleman-blog.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
   
-  s.add_dependency("middleman-core", ["~> 3.0.1"])
+  s.add_dependency("middleman-core", ["~> 3.0"])
   s.add_dependency("maruku", ["~> 0.6.0"])
   s.add_dependency("tzinfo", ["~> 0.3.0"])
+  s.add_dependency("nokogiri", ["~> 1.5.6"])
 end


### PR DESCRIPTION
From the updated Changelog:
- The `summary` method on articles is now HTML-aware, and can be provided with a different summary length or ellipsis string: `summary(1000, '&hellip;')`
- The `summary_generator` option now recieves the rendered article (without layout) instead of the template source.
- Set `summary_length` to false to always use the full article as a summary.
