### PR TITLE
Remove nokogiri dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,20 +9,17 @@ end
 # Specify your gem's dependencies in middleman-blog.gemspec
 gemspec
 
-group :development do
-  gem "rake",     "~> 0.9.2"
-  gem "rdoc",     "~> 3.9"
-  gem "yard",     "~> 0.8.0"
-end
+gem "rake",     "~> 0.9.2"
+gem "rdoc",     "~> 3.9"
+gem "yard",     "~> 0.8.0"
 
-group :test do
-  gem "cucumber", "~> 1.2.0"
-  gem "fivemat"
-  gem "aruba",    "~> 0.4.11"
-  gem "rspec",    "~> 2.7"
-  gem "timecop",  "~> 0.4.0"
-  
-  platforms :ruby do
-    gem "redcarpet"
-  end
+gem "cucumber", "~> 1.2.0"
+gem "fivemat"
+gem "aruba",    "~> 0.4.11"
+gem "rspec",    "~> 2.7"
+gem "timecop",  "~> 0.4.0"
+gem "nokogiri"
+
+platforms :ruby do
+  gem "redcarpet", "~> 2.1.1"
 end

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -1,6 +1,5 @@
 require 'active_support/time_with_zone'
 require 'active_support/core_ext/time/calculations'
-require 'middleman-blog/truncate_html'
 
 module Middleman
   module Blog
@@ -82,6 +81,8 @@ module Middleman
       end
 
       def default_summary_generator(rendered, length, ellipsis)
+        require 'middleman-blog/truncate_html'
+
         if rendered =~ app.blog.options.summary_separator
           rendered.split(app.blog.options.summary_separator).first
         elsif length

--- a/lib/middleman-blog/template/source/feed.xml.builder
+++ b/lib/middleman-blog/template/source/feed.xml.builder
@@ -16,7 +16,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.published article.date.to_time.iso8601
       xml.updated article.date.to_time.iso8601
       xml.author { xml.name "Article Author" }
-      xml.summary article.summary, "type" => "html"
+      # xml.summary article.summary, "type" => "html"
       xml.content article.body, "type" => "html"
     end
   end

--- a/lib/middleman-blog/template/source/index.html.erb
+++ b/lib/middleman-blog/template/source/index.html.erb
@@ -12,7 +12,9 @@ per_page: 10
 
 <% page_articles.each_with_index do |article, i| %>
   <h2><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></h2>
-  <%= article.summary %>
+  <!-- use article.summary(250) if you have Nokogiri available to show just
+       the first 250 characters -->
+  <%= article.body %>
 <% end %>
 
 <% if paginate %>

--- a/lib/middleman-blog/truncate_html.rb
+++ b/lib/middleman-blog/truncate_html.rb
@@ -1,4 +1,8 @@
-require "nokogiri"
+begin
+  require "nokogiri"
+rescue LoadError
+  raise "Nokogiri is required for blog post summaries. Add 'nokogiri' to your Gemfile."
+end
 
 # Taken and modified from http://madebydna.com/all/code/2010/06/04/ruby-helper-to-cleanly-truncate-html.html
 # MIT license

--- a/middleman-blog.gemspec
+++ b/middleman-blog.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |s|
   s.add_dependency("middleman-core", ["~> 3.0.0"])
   s.add_dependency("maruku", ["~> 0.6.0"])
   s.add_dependency("tzinfo", ["~> 0.3.0"])
-  s.add_dependency("nokogiri", ["~> 1.5.6"])
 end


### PR DESCRIPTION
I added a dependency on Nokogiri for blog summaries, but @tdreyno points out that Nokogiri is hard for some people to install, and thus shouldn't be a hard dependency. This issue is to track either removing Nokogiri or making it a soft dependency.
