### PR TITLE
Allow options.sources to contain the same date component multiple times

### DIFF
--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -29,9 +29,9 @@ module Middleman
         
         matcher = Regexp.escape(options.sources).
             sub(/^\//, "").
-            sub(":year",  "(\\d{4})").
-            sub(":month", "(\\d{2})").
-            sub(":day",   "(\\d{2})").
+            gsub(":year",  "(\\d{4})").
+            gsub(":month", "(\\d{2})").
+            gsub(":day",   "(\\d{2})").
             sub(":title", "([^/]+)")
 
         subdir_matcher = matcher.sub(/\\\.[^.]+$/, "(/.*)$")


### PR DESCRIPTION
I organize my blog posts into folders by year, like so:

```
posts/
├── 2008
│   └── 2008-12-15-title.md
├── 2009
│   └── 2009-10-23-title.md
├── 2010
│   └── 2010-08-26-title.md
├── 2011
│   └── 2011-10-27-title.md
└── 2012
    └── 2012-10-29-title.md
```

In configuring `middleman-blog`s sources option, I expected support for file name globbing, but was unable to use the expected globing pattern:

`blog.sources = "posts/*/:year-:month-:day-:title"`

Adding globbing support seemed like it might be a fair bit of work based on the ways the sources option is used in the code, so I opted to add the ability to use date keywords multiple times in the sources option, like so:

`blog.sources = "posts/:year/:year-:month-:day-:title"`
