### PR TITLE
Change RubyGems source

### DIFF
--- a/lib/middleman-blog/template/shared/Gemfile.tt
+++ b/lib/middleman-blog/template/shared/Gemfile.tt
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+# If you have OpenSSL installed, we recommend updating
+# the following line to use "https"
+source 'http://rubygems.org'
 
 gem "middleman", "~> <%= Middleman::VERSION %>"
 gem "middleman-blog", "~> <%= Middleman::Blog::VERSION %>"


### PR DESCRIPTION
``` bash
$ bundle
```

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
