### PR TITLE
Functionality for custom_article.tt

### DIFF
--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -41,7 +41,7 @@ module Middleman
             sub(':day', @date.day.to_s.rjust(2,'0')).
             sub(':title', @slug)
 
-          custom_template = shared_instance.source_dir + '/custom_template.tt'
+          custom_template = shared_instance.source_dir + '/custom_article.tt'
 
           if File.file?(custom_template)
             template custom_template , File.join(shared_instance.source_dir, article_path + shared_instance.blog.options.default_extension)


### PR DESCRIPTION
If you want to generate an article with the 'middleman article TITLE' command it can be nice to have the possibility to use a custom article template.

the custom article template must be named 'custom_article.tt' and be located in the 'source'-folder. 

What do you think?
