### PR TITLE
Hide page numbers if only one page per index

### DIFF
--- a/lib/middleman-blog/template/source/calendar.html.erb
+++ b/lib/middleman-blog/template/source/calendar.html.erb
@@ -12,7 +12,7 @@ pageable: true
   <% end %>
 </h1>
 
-<% if paginate %>
+<% if paginate && num_pages > 1 %>
   <p>Page <%= page_number %> of <%= num_pages %></p>
 
   <% if prev_page %>

--- a/lib/middleman-blog/template/source/index.html.erb
+++ b/lib/middleman-blog/template/source/index.html.erb
@@ -2,7 +2,7 @@
 pageable: true
 per_page: 10
 ---
-<% if paginate %>
+<% if paginate && num_pages > 1 %>
   <p>Page <%= page_number %> of <%= num_pages %></p>
 
   <% if prev_page %>

--- a/lib/middleman-blog/template/source/tag.html.erb
+++ b/lib/middleman-blog/template/source/tag.html.erb
@@ -4,7 +4,7 @@ per_page: 12
 ---
 <h1>Articles tagged '<%= tagname %>'</h1>
 
-<% if paginate %>
+<% if paginate && num_pages > 1 %>
   <p>Page <%= page_number %> of <%= num_pages %></p>
 
   <% if prev_page %>


### PR DESCRIPTION
This avoids displaying "Page 1 of 1" when pagination is turned on, but the
current index page doesn't have enough articles to fill more than one page.
