### PR TITLE
Make builder an official dependency

### DIFF
--- a/lib/middleman-blog/template/shared/Gemfile.tt
+++ b/lib/middleman-blog/template/shared/Gemfile.tt
@@ -4,6 +4,3 @@ source 'http://rubygems.org'
 
 gem "middleman", "~> <%= Middleman::VERSION %>"
 gem "middleman-blog", "~> <%= Middleman::Blog::VERSION %>"
-
-# For feed.xml.builder
-gem "builder", "~> 3.0.0"

--- a/middleman-blog.gemspec
+++ b/middleman-blog.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency("middleman-more", ["~> 3.0"])
   s.add_dependency("kramdown", ["~> 1.0.0"])
   s.add_dependency("tzinfo", ["~> 0.3.0"])
+  s.add_dependency("builder", ["~> 3.0"])
 end


### PR DESCRIPTION
Instead of only in the generated Gemfile template. Also allow for builder
3.x instead of just 3.0.x
