### PR TITLE
Relaxed generated dependency on builder

### DIFF
--- a/lib/middleman-blog/template/shared/Gemfile.tt
+++ b/lib/middleman-blog/template/shared/Gemfile.tt
@@ -6,4 +6,4 @@ gem "middleman", "~> <%= Middleman::VERSION %>"
 gem "middleman-blog", "~> <%= Middleman::Blog::VERSION %>"
 
 # For feed.xml.builder
-gem "builder", "~> 3.0.0"
+gem "builder", "~> 3.0"


### PR DESCRIPTION
This allows for and better declares that builder 3.x is okay instead of just 3.0.x.

Somewhat related to #127
