### PR TITLE
Kramdown is krammed down our throats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rspec",    "~> 2.12"
 
 gem "timecop",  "~> 0.4.0"
 gem "nokogiri"
+gem "kramdown"
 
 # Code Quality
 gem "cane", :platforms => [:mri_19, :mri_20], :require => false

--- a/lib/middleman-blog/extension_3_0.rb
+++ b/lib/middleman-blog/extension_3_0.rb
@@ -35,11 +35,9 @@ module Middleman
         end
       end
     end
-    
+
     class << self
       def registered(app, options_hash={}, &block)
-        app.set :markdown_engine, :kramdown
-
         require 'middleman-blog/blog_data'
         require 'middleman-blog/blog_article'
         require 'active_support/core_ext/time/zones'

--- a/middleman-blog.gemspec
+++ b/middleman-blog.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency("middleman-core", ["~> 3.0"])
   s.add_dependency("middleman-more", ["~> 3.0"])
-  s.add_dependency("kramdown", ["~> 1.0.0"])
   s.add_dependency("tzinfo", ["~> 0.3.0"])
 end


### PR DESCRIPTION
(sorry, couldn't help the pun)

[This change](https://github.com/middleman/middleman-blog/commit/03d2db9b2adf3680ce3a03beace333892d8c5586#L1L40) sets kramdown as the markdown engine when a blog is activated. 

This change does not allow for the markdown engine to be specified (as something other than kramdown) before the blog is activated in config.rb. Instead, for example, if you want to use redcarpet or maruku, you must now set the markdown engine _after_ activating the blog. 

Even though I understand that the default markdown engine is changing from maruku to kramdown, I don't understand the necessity of this forced setting to kramdown since a default markdown engine is already specified in middleman-more.

My suggestion is to remove this forced markdown engine behavior from middleman-blog. If the middleman-blog test suite needs kramdown, then I would suggest that it only be hard set in the test suite, not for all blogs.

I'm willing to work on cleaning this up, but I first wanted to open the discussion in case I'm missing something very important. 
