### PR TITLE
Make feed.xml entry URLs absolute

### DIFF
--- a/lib/middleman-blog/template/source/feed.xml.builder
+++ b/lib/middleman-blog/template/source/feed.xml.builder
@@ -12,8 +12,8 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   blog.articles[0..5].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => article.url
-      xml.id article.url
+      xml.link "rel" => "alternate", "href" => URL.join(site_url, article.url)
+      xml.id URL.join(site_url, article.url)
       xml.published article.date.to_time.iso8601
       xml.updated File.mtime(article.source_file).iso8601
       xml.author { xml.name "Article Author" }


### PR DESCRIPTION
- w3c atom feed validator requires absolute URLs for ids
- absolute URLs on link tags should work with more feed readers
