### PR TITLE
Fix calls to URI.join in feed.xml.builder

### DIFF
--- a/lib/middleman-blog/template/source/feed.xml.builder
+++ b/lib/middleman-blog/template/source/feed.xml.builder
@@ -5,15 +5,15 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.subtitle "Blog subtitle"
   xml.id URI.join(site_url, blog.options.prefix.to_s)
   xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
-  xml.link "href" => URL.join(site_url, current_page.path), "rel" => "self"
+  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
   xml.updated blog.articles.first.date.to_time.iso8601
   xml.author { xml.name "Blog Author" }
 
   blog.articles[0..5].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => URL.join(site_url, article.url)
-      xml.id URL.join(site_url, article.url)
+      xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
+      xml.id URI.join(site_url, article.url)
       xml.published article.date.to_time.iso8601
       xml.updated File.mtime(article.source_file).iso8601
       xml.author { xml.name "Article Author" }


### PR DESCRIPTION
`URL.join` is called on lines 8, 15, and 16 of the [feed.xml.builder](https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/template/source/feed.xml.builder) file. It should be `URI.join`.
