### PR TITLE
Don't truncate comments in the summary

### DIFF
--- a/features/summary.feature
+++ b/features/summary.feature
@@ -36,3 +36,8 @@ Feature: Article summary generation
     Then I should not see "Summary from article with no separator"
     Then I should not see "Extended part from article"
 
+  Scenario: Article has comments in the summary and no summary separator
+    Given the Server is running at "summary-app"
+    When I go to "/index.html"
+    Then I should see "Summary from article with no summary separator and comments in the summary."
+    Then I should not see "Extended part from article from article with no summary separator and comments in the summary."

--- a/fixtures/summary-app/source/2011-01-01-article-with-no-summary-separator-and-comments-in-the-summary.html.erb
+++ b/fixtures/summary-app/source/2011-01-01-article-with-no-summary-separator-and-comments-in-the-summary.html.erb
@@ -1,0 +1,10 @@
+---
+title: "Article with no summary separator and comments in the summary"
+---
+
+<p>Summary from article with no summary separator and comments in the summary.</p>
+
+<p>Lorem ipsum <!-- html comment --> dolor sit amet, consectetur adipiscing elit. Nullam tempus, sem non bibendum placerat, urna augue bibendum lectus, id fringilla ligula turpis semper quam. Mauris malesuada g
+  ravida viverra. Sed quis turpis neque, eu posuere dolor. Integer risus nulla, molestie sit amet convallis eu, vulputate eget ligula. Aenean aliquet euismod magna, convallis ultrices diam tristique in. Suspendisse potenti. In nunc odio, lobortis at ullamcorper sit amet, placerat eget massa. Sed ultrices sapien in sapien vulputate sed tincidunt turpis viverra. Vestibulum aliquam lacus nec ante rutrum tempus nec non nisi. Quisque imperdiet ultricies lectus in feugiat. Praesent vel aliquet odio. Quisque sed dui non metus congue ullamcorper. Donec quis libero tellus. Nulla ullamcorper turpis eget felis facilisis ut tincidunt lorem porta. Integer id quam elit, quis sollicitudin felis. Vestibulum eu arcu orci, a tristique nunc.</p>
+
+<p>Extended part from article with no summary separator and comments in the summary.</p>

--- a/lib/middleman-blog/truncate_html.rb
+++ b/lib/middleman-blog/truncate_html.rb
@@ -47,8 +47,16 @@ module NokogiriTruncator
     end
   end
 
+  module CommentNode
+    def truncate(*args)
+      # Don't truncate comments, since they aren't visible
+      self
+    end
+  end
+
 end
 
 Nokogiri::HTML::DocumentFragment.send(:include, NokogiriTruncator::NodeWithChildren)
 Nokogiri::XML::Element.send(:include, NokogiriTruncator::NodeWithChildren)
 Nokogiri::XML::Text.send(:include, NokogiriTruncator::TextNode)
+Nokogiri::XML::Comment.send(:include, NokogiriTruncator::CommentNode)


### PR DESCRIPTION
When there wasn't a summary separator, and the node being truncated had a
comment, a NoMethodError exception was raised when calling truncate on an
instance of Nokogiri::XML::Comment.
