### PR TITLE
Fix to set time zone

### DIFF
--- a/features/time_zone.feature
+++ b/features/time_zone.feature
@@ -1,0 +1,5 @@
+Feature: Setup time zoen
+  Scenario: Time.zone can be set through set at config.rb
+    Given the Server is running at "time-zone-app"
+    When I go to "/blog/2013/06/24/hello.html"
+    Then I should see "(GMT+09:00) Tokyo"

--- a/fixtures/time-zone-app/config.rb
+++ b/fixtures/time-zone-app/config.rb
@@ -1,0 +1,5 @@
+set :time_zone, 'Tokyo'
+
+activate :blog do |blog|
+  blog.prefix = 'blog'
+end

--- a/fixtures/time-zone-app/source/blog/2013-06-24-hello.html.erb
+++ b/fixtures/time-zone-app/source/blog/2013-06-24-hello.html.erb
@@ -1,0 +1,5 @@
+---
+title: Time zone
+layout: false
+---
+<%= Time.zone.to_s %>

--- a/lib/middleman-blog/extension_3_0.rb
+++ b/lib/middleman-blog/extension_3_0.rb
@@ -42,8 +42,6 @@ module Middleman
         require 'middleman-blog/blog_article'
         require 'active_support/core_ext/time/zones'
 
-        app.set :time_zone, 'UTC'
-
         app.send :include, Helpers
 
         options = Options.new(options_hash)
@@ -90,6 +88,7 @@ module Middleman
           # Make sure ActiveSupport's TimeZone stuff has something to work with,
           # allowing people to set their desired time zone via Time.zone or
           # set :time_zone
+          Time.zone = self.time_zone if self.respond_to?(:time_zone)
           time_zone = Time.zone if Time.zone
           zone_default = Time.find_zone!(time_zone || 'UTC')
           unless zone_default

--- a/lib/middleman-blog/extension_3_1.rb
+++ b/lib/middleman-blog/extension_3_1.rb
@@ -74,6 +74,7 @@ module Middleman
       # Make sure ActiveSupport's TimeZone stuff has something to work with,
       # allowing people to set their desired time zone via Time.zone or
       # set :time_zone
+      Time.zone = app.config[:time_zone] if app.config[:time_zone]
       time_zone = Time.zone if Time.zone
       zone_default = Time.find_zone!(time_zone || 'UTC')
       unless zone_default


### PR DESCRIPTION
The following configuration is OK.

``` ruby
# config.rb
Time.zone = 'Tokyo'
```

But the following configuration is ignored.

``` ruby
# cofig.rb
set :time_zone, 'Tokyo'
```

So I fixed to set `Time.zone` through `set :time_zone`.
