### PR TITLE
Fix middleman version

### DIFF
--- a/Gemfile-3.0
+++ b/Gemfile-3.0
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+gem "middleman-core", "~> 3.0.0"
+gem "middleman-more", "~> 3.0.0"
+
 # Specify your gem's dependencies in middleman-blog.gemspec
 gemspec
 


### PR DESCRIPTION
Now middleman 3.1 has been released.
So I fixed Gemfile to require middleman 3.0.x.
