### PR TITLE
Use Redcarpet 3.0 if possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "kramdown"
 gem "cane", :platforms => [:mri_19, :mri_20], :require => false
 
 platforms :ruby do
-  gem "redcarpet", "~> 2.3.0"
+  gem "redcarpet", /^1\.8/.match(RUBY_VERSION) ? "~> 2.0" : "~> 3.0"
 end
 
 # Cross-templating language block fix for Ruby 1.8


### PR DESCRIPTION
Following middleman/middleman's choice of Redcarpet if Ruby version is 1.9+
