### PR TITLE
Add inspect methods to data and article

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -194,6 +194,10 @@ module Middleman
       def next_article
         blog_data.articles.reverse.find {|a| a.date > self.date }
       end
+
+      def inspect
+        "#<Middleman::Blog::BlogArticle: #{data.inspect}>"
+      end
     end
   end
 end

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -148,6 +148,10 @@ module Middleman
         
         used_resources
       end
+
+      def inspect
+        "#<Middleman::Blog::BlogData: #{articles.inspect}>"
+      end
     end
   end
 end


### PR DESCRIPTION
This is fix to following scenario:

If blog has many entries, then typing blog.tags in middleman console hangs application. This is because of enormous `inspect` of `BlogArticle` and `BlogData`. For me it happened in template so server / build script hanged.

The fix is to add explicit inspect methods to both `BlogArticle` and `BlogData`.
