### PR TITLE
Fail hard when using multiblog and blog name is not specified

### DIFF
--- a/features/tags_multiblog.feature
+++ b/features/tags_multiblog.feature
@@ -89,7 +89,7 @@ Feature: Tag pages with multiple blogs
     Then I should see "Not Found"
     And the file "source/blog1/2011-01-01-new-article.html.markdown" has the contents
       """
-      --- 
+      ---
       title: "Newest Article"
       date: 2011-01-01
       tags: newtag1, newtagX
@@ -99,7 +99,7 @@ Feature: Tag pages with multiple blogs
       """
     And the file "source/blog2/2011-01-01-new-article.html.markdown" has the contents
       """
-      --- 
+      ---
       title: "Newest Article"
       date: 2011-01-01
       tags: newtag2, newtagX
@@ -123,7 +123,7 @@ Feature: Tag pages with multiple blogs
     When I go to "/blog2/tags/newtagx.html"
     Then I should see "/blog2/2011-01-01-new-article.html"
     Then I should not see "/blog1/2011-01-01-new-article.html"
-    
+
   Scenario: Blog data should work when blog name is specified
     Given the Server is running at "tags-multiblog-app"
     When I go to "/blog1/named_blog_tags.html"
@@ -137,21 +137,15 @@ Feature: Tag pages with multiple blogs
     Then I should see "fooX (2)"
     Then I should see "barX (1)"
 
-  Scenario: Blog data should default to current blog
+  Scenario: Blog data should use blog name in frontmatter
     Given the Server is running at "tags-multiblog-app"
-    When I go to "/blog1/current_blog_tags.html"
+    When I go to "/blog1/frontmatter_blog_tags.html"
     Then I should see "foo1 (2)"
     Then I should see "bar1 (1)"
     Then I should see "fooX (2)"
     Then I should see "barX (1)"
-    When I go to "/blog2/current_blog_tags.html"
+    When I go to "/blog2/frontmatter_blog_tags.html"
     Then I should see "foo2 (2)"
     Then I should see "bar2 (1)"
     Then I should see "fooX (2)"
     Then I should see "barX (1)"
-    
-
-
-
-
-

--- a/fixtures/multiblog-app/source/index.html.erb
+++ b/fixtures/multiblog-app/source/index.html.erb
@@ -1,5 +1,3 @@
-<p>Default blog length: <%= blog.articles.length %></p>
-
 <p>blog_number_1 length: <%= blog(:blog_number_1).articles.length %></p>
 <p>blog_number_1 title: <%= blog(:blog_number_1).articles[0].data.title %></p>
 

--- a/fixtures/tags-multiblog-app/source/blog1/current_blog_tags.html
+++ b/fixtures/tags-multiblog-app/source/blog1/current_blog_tags.html
@@ -1,5 +1,0 @@
-<% blog("blog_name_1").tags.each do |tag, articles| %>
-  <section>
-    <h2><%= tag %> (<%= articles.size %>)</h2>    
-  </section>
-<% end %>

--- a/fixtures/tags-multiblog-app/source/blog1/current_blog_tags.html.erb
+++ b/fixtures/tags-multiblog-app/source/blog1/current_blog_tags.html.erb
@@ -1,5 +1,0 @@
-<% blog().tags.each do |tag, articles| %>
-  <section>
-    <h2><%= tag %> (<%= articles.size %>)</h2>    
-  </section>
-<% end %>

--- a/fixtures/tags-multiblog-app/source/blog1/frontmatter_blog_tags.html.erb
+++ b/fixtures/tags-multiblog-app/source/blog1/frontmatter_blog_tags.html.erb
@@ -1,0 +1,9 @@
+---
+blog: blog_name_1
+---
+
+<% blog().tags.each do |tag, articles| %>
+  <section>
+    <h2><%= tag %> (<%= articles.size %>)</h2>
+  </section>
+<% end %>

--- a/fixtures/tags-multiblog-app/source/blog2/current_blog_tags.html.erb
+++ b/fixtures/tags-multiblog-app/source/blog2/current_blog_tags.html.erb
@@ -1,5 +1,0 @@
-<% blog().tags.each do |tag, articles| %>
-  <section>
-    <h2><%= tag %> (<%= articles.size %>)</h2>    
-  </section>
-<% end %>

--- a/fixtures/tags-multiblog-app/source/blog2/frontmatter_blog_tags.html.erb
+++ b/fixtures/tags-multiblog-app/source/blog2/frontmatter_blog_tags.html.erb
@@ -1,0 +1,9 @@
+---
+blog: blog_name_2
+---
+
+<% blog().tags.each do |tag, articles| %>
+  <section>
+    <h2><%= tag %> (<%= articles.size %>)</h2>
+  </section>
+<% end %>

--- a/lib/middleman-blog/extension_3_1.rb
+++ b/lib/middleman-blog/extension_3_1.rb
@@ -186,7 +186,16 @@ module Middleman
       end
 
       def blog_controller(key=nil)
-        key ||= (current_resource && current_resource.metadata[:page]["blog"]) || blog_instances.keys.first
+        if !key && current_resource
+          key ||= current_resource.metadata[:page]["blog"]
+        end
+
+        # In multiblog situations, force people to specify the blog
+        if !key && blog_instances.size > 1
+          raise "You must either specify the blog name in calling this method or in your page frontmatter (using the 'blog' key)"
+        end
+
+        key ||= blog_instances.keys.first
         blog_instances[key.to_sym]
       end
 


### PR DESCRIPTION
Previously all helpers would just default to "first blog" unless specified. This change causes Middleman to fail with an exception instead, forcing users to specify the blog in either the helper arguments or via frontmatter. Single-blog sites are unaffected. There essentially is no longer a concept of "default blog".

This aims to prevent the confusion from issue #166.
