### PR TITLE
Add public_draft option for peer reviews.

### DIFF
--- a/features/public_draft.feature
+++ b/features/public_draft.feature
@@ -1,0 +1,49 @@
+Feature: Public draft articles
+  Scenario: Public draft articles show up in the preview server
+    Given the Server is running at "public-draft-app"
+    When I go to "/2011/01/01/new-article.html"
+    Then I should see "Newer Article Content"
+    When I go to "/2012/06/19/draft-article.html"
+    Then I should see "This is a draft"
+    When I go to "/2012/06/19/draft-article/example.txt"
+    Then I should see "Example Text"
+    When I go to "/"
+    Then I should see "Newer Article Content"
+    Then I should see "This is a draft"
+
+  Scenario: Public draft articles are not listed when the environment is not :development
+    Given a fixture app "public-draft-app"
+    And a file named "config.rb" with:
+      """
+      set :environment, :production
+      activate :blog do |blog|
+        blog.sources = "blog/:year-:month-:day-:title.html"
+      end
+      """
+    Given the Server is running at "public-draft-app"
+    When I go to "/"
+    Then I should see "Newer Article Content"
+    Then I should not see "This is a draft"
+
+  Scenario: Public draft articles are accessible when the environment is not :development
+    Given a fixture app "public-draft-app"
+    And a file named "config.rb" with:
+      """
+      set :environment, :production
+      activate :blog do |blog|
+        blog.sources = "blog/:year-:month-:day-:title.html"
+      end
+      """
+    Given the Server is running at "public-draft-app"
+    When I go to "/2012/06/19/draft-article.html"
+    Then I should see "This is a draft"
+    When I go to "/2012/06/19/draft-article/example.txt"
+    Then I should see "Example Text"
+
+  Scenario: Public draft arcticles get built
+    Given a successfully built app at "public-draft-app"
+    When I cd to "build"
+    Then the following files should exist:
+      | 2012/06/19/draft-article.html        |
+      | 2012/06/19/draft-article/example.txt |
+      | 2011/01/01/new-article.html          |

--- a/fixtures/public-draft-app/config.rb
+++ b/fixtures/public-draft-app/config.rb
@@ -1,0 +1,3 @@
+activate :blog do |blog|
+  blog.sources = "blog/:year-:month-:day-:title.html"
+end

--- a/fixtures/public-draft-app/source/_article_template.erb
+++ b/fixtures/public-draft-app/source/_article_template.erb
@@ -1,0 +1,1 @@
+<%= current_article.url %>

--- a/fixtures/public-draft-app/source/blog/2011-01-01-new-article.html.markdown
+++ b/fixtures/public-draft-app/source/blog/2011-01-01-new-article.html.markdown
@@ -1,0 +1,6 @@
+--- 
+title: "Newer Article"
+date: 2011-01-01
+---
+
+Newer Article Content

--- a/fixtures/public-draft-app/source/blog/2012-06-19-draft-article.html.markdown
+++ b/fixtures/public-draft-app/source/blog/2012-06-19-draft-article.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "Draft Article"
+date: 2012-06-19
+public_draft: true
+---
+
+This is a draft

--- a/fixtures/public-draft-app/source/blog/2012-06-19-draft-article/example.txt
+++ b/fixtures/public-draft-app/source/blog/2012-06-19-draft-article/example.txt
@@ -1,0 +1,1 @@
+Example Text

--- a/fixtures/public-draft-app/source/index.html.erb
+++ b/fixtures/public-draft-app/source/index.html.erb
@@ -1,0 +1,9 @@
+<% blog.articles[0...5].each_with_index do |article, i| %>
+  <article class="<%= (i == 0) ? 'first' : '' %>">
+    <h1><a href="<%= article.url %>"><%= article.title %></a> <span><%= article.date.strftime('%b %e %Y') %></span></h1>
+    
+    <%= article.summary %>
+    
+    <div class="more"><a href="<%= article.url %>">read on &raquo;</a></div>
+  </article>
+<% end %>

--- a/fixtures/public-draft-app/source/layout.erb
+++ b/fixtures/public-draft-app/source/layout.erb
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <% if is_blog_article? %>
+      <%= yield %>
+      <%= current_article.url %>
+    <% else %>
+      <%= yield %>
+    <% end %>
+  </body>
+</html>

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -54,7 +54,11 @@ module Middleman
       # A list of all blog articles, sorted by descending date
       # @return [Array<Middleman::Sitemap::Resource>]
       def articles
-        @_articles.sort_by(&:date).reverse
+        if @app.environment != :development
+          @_articles.reject{|a| a.data.public_draft }.sort_by(&:date).reverse
+        else
+          @_articles.sort_by(&:date).reverse
+        end
       end
 
       # The BlogArticle for the given path, or nil if one doesn't exist.


### PR DESCRIPTION
Adds a `public_draft: true` option for your YAML frontmatter so that your articles are always built but not available for listings in `blog.articles`

This is especially useful when you want to share an article for peer review while not listing it publicly on your index page or RSS feed, etc

Notes:
- I will gladly open another pull request to update [draft articles section](https://github.com/middleman/middleman-guides/blob/master/source/blogging.html.markdown#draft-articles) of the guide if needed (uncertain about how you guys keep the docs and releases in sync though)
- It is the first time that I write cucumber features and it was heavily cargo culted from the published-app features. Do let me know if you have any feedback about that.
- Features are still all passing for me, but the 2 Gemfiles are a bit confusing. I only got them to pass if I point to Gemfile-3.0 like so: `BUNDLE_GEMFILE=/Users/vincentroy8/code/middleman-blog/Gemfile-3.0 bundle exec rake test`
