### PR TITLE
Add autodiscovery of feed.xml to layout.erb

### DIFF
--- a/lib/middleman-blog/template/source/layout.erb
+++ b/lib/middleman-blog/template/source/layout.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv='X-UA-Compatible' content='IE=edge;chrome=1' />
     <title>Blog Title<%= ' - ' + current_article.title unless current_article.nil? %></title>
+    <%= feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml"), title: "Atom Feed" %>
   </head>
   <body>
     


### PR DESCRIPTION
Some users forget to add a link or something to `feed.xml` and visitors to their blog can't notice the feed.
This change would be helpful for them.

---

The Travis CI build failed because of `cannot load such file -- middleman-more/extensions/automatic_alt_tags`. I think this is related to the problem mentioned in [Pull Request #1072 in middleman/middleman](https://github.com/middleman/middleman/pull/1072), not to this change.
