### PR TITLE
implement summary with unlimited length

### DIFF
--- a/features/summary.feature
+++ b/features/summary.feature
@@ -41,3 +41,16 @@ Feature: Article summary generation
     When I go to "/index.html"
     Then I should see "Summary from article with no summary separator and comments in the summary."
     Then I should not see "Extended part from article from article with no summary separator and comments in the summary."
+
+  Scenario: Summary is only limited by a optional summary separator and not by length
+    Given a fixture app "summary-app"
+    And a file named "config.rb" with:
+      """
+      activate :blog do |blog|
+        blog.summary_length = -1
+      end
+      """
+    Given the Server is running at "summary-app"
+    When I go to "/index.html"
+    Then I should see "Extended part from article with no separator."
+    Then I should not see "Extended part from article with separator."

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -93,6 +93,8 @@ module Middleman
 
         if blog_options.summary_separator && rendered.match(blog_options.summary_separator)
           rendered.split(blog_options.summary_separator).first
+        elsif blog_options.summary_separator && length < 0
+          rendered
         elsif blog_options.summary_generator
           blog_options.summary_generator.call(self, rendered, length, ellipsis)
         else


### PR DESCRIPTION
this commit fixes middleman/middleman#1074

If the summary_length is set to any value smaller than 0
and a summary_separtor is defined than the summary is
generated in case of
a) no separtor found in article: whole article (summary = article)
b) separator found in article: article until the occurence of the separator

This is my first pull request ever. So please be gentle with me. :grin: 

As soon as this got accepted I will add another pull request on middleman-guide to add a paragraph about it.
