### PR TITLE
Fix broken link to middleman blog extension guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ activate :blog
 
 ## Learn More
 
-See [the blog extension guide](http://middlemanapp.com/blogging/) for detailed information on configuring and using the blog extension.
+See [the blog extension guide](http://middlemanapp.com/basics/blogging/) for detailed information on configuring and using the blog extension.
 
 Additionally, up-to-date generated code documentation is available on [RubyDoc].
 


### PR DESCRIPTION
Users were being sent to a page that said this:

![](http://cl.ly/image/1e2f3C1d1u0W/Screen%20Shot%202013-11-29%20at%209.21.45%20PM.png)
