### PR TITLE
Summary missing closing paragraph tag when using markdown

### DIFF
--- a/features/summary.feature
+++ b/features/summary.feature
@@ -7,6 +7,9 @@ Feature: Article summary generation
     Then I should see "Summary from article with no separator."
     Then I should not see "Extended part from article with no separator."
 
+    When I go to "/index.html"
+    Then I should see "<p>Summary from article with separator.</p>"
+
   Scenario: Article has custom summary separator
     Given a fixture app "summary-app"
     And a file named "config.rb" with:
@@ -21,7 +24,10 @@ Feature: Article summary generation
     Then I should not see "Extended part from article with custom separator."
     Then I should see "Extended part from article with separator."
 
-  Scenario: Using a custom summary generator
+    When I go to "/index.html"
+    Then I should see "<p>Summary from article with custom separator.</p>"
+
+  Scenario: Using a custom   generator
     Given a fixture app "summary-app"
     And a file named "config.rb" with:
       """


### PR DESCRIPTION
When I allow a summary to be generated using a summary separator on a markdown enabled article I end up missing a `</p>` tag. It looks like the paragraph is being closed after the summary separator (by markdown) and then, when the rendered content is split in order to create the summary, the closing paragraph is lost in the discarded section.

I thought of splitting the content before rendering and then applying the markdown to the content before the summary separator but I came across the problems outlined in issue #80. Right now I have no solution for this, so I've merely tweaked the tests to report on the problem.
