### PR TITLE
Fix tag and year links

### DIFF
--- a/lib/middleman-blog/template/source/layout.erb
+++ b/lib/middleman-blog/template/source/layout.erb
@@ -23,14 +23,14 @@
       <h2>Tags</h2>
       <ol>
         <% blog.tags.each do |tag, articles| %>
-          <li><%= link_to tag, tag_path(tag) %> (<%= articles.size %>)</a></li>
+          <li><%= link_to "#{tag} (#{articles.size})", tag_path(tag) %></li>
         <% end %>
       </ol>
 
       <h2>By Year</h2>
       <ol>
         <% blog.articles.group_by {|a| a.date.year }.each do |year, articles| %>
-          <li><%= link_to year, blog_year_path(year) %> (<%= articles.size %>)</a></li>
+          <li><%= link_to "#{year} (#{articles.size})", blog_year_path(year) %></li>
         <% end %>
       </ol>
     </aside>


### PR DESCRIPTION
Hi,

This is just a little pull request that fixes slight mistakes in 06bc5193cf3b7ae7b403ed1795a1b72cf065e9f7.
- Remove stray end tag for element 'a'
- Include article.size as part of the link caption

These fixes are based on previous state of 06bc5193cf3b7ae7b403ed1795a1b72cf065e9f7.

Thank you for your attention.
