### PR TITLE
Remove middleman-core dependency in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem "middleman-core", :github => "middleman/middleman", :branch => "v3-stable"
+
 # Specify your gem's dependencies in middleman-blog.gemspec
 gemspec
 


### PR DESCRIPTION
`middleman-core` declared dependency at `middleman-blog.gemspec`, no need in `Gemfile`

Keeping `gem 'middleman-core'`, `bundle` will raise

```
Bundler could not find compatible versions for gem "middleman-core":
  In Gemfile:
    middleman-blog (>= 0) ruby depends on
      middleman-core (~> 3.2) ruby

    middleman-core (4.0.0.pre.0)
```

cause `middleman-core` has bumped to 4.x in its master branch
