### PR TITLE
Support numeric parameters.

### DIFF
--- a/lib/middleman-blog/uri_templates.rb
+++ b/lib/middleman-blog/uri_templates.rb
@@ -49,7 +49,7 @@ module Middleman
         sep = '-'
 
         # Reimplementation of http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-parameterize that preserves un-transliterate-able multibyte chars.
-        parameterized_string = ActiveSupport::Inflector.transliterate(str).downcase
+        parameterized_string = ActiveSupport::Inflector.transliterate(str.to_s).downcase
         parameterized_string.gsub!(/[^a-z0-9\-_\?]+/, sep)
 
         parameterized_string.chars.to_a.each_with_index do |char, i|

--- a/spec/uri_templates_spec.rb
+++ b/spec/uri_templates_spec.rb
@@ -22,6 +22,10 @@ describe 'Middleman::Blog::UriTemplates' do
     it "can handle mixed strings" do
       safe_parameterize('What ☆☆☆!').should == 'what-☆☆☆'
     end
+
+    it "can handle numbers" do
+      safe_parameterize(1).should == '1'
+    end
   end
 
   describe 'extract_params' do


### PR DESCRIPTION
Currently if a number is supplied there is a error raised "undefined method 'unpack' for 1:Fixnum". This pull requests enforces the type to become a string before sending the `transliterate` message to `ActiveSupport::Inflector`.
