### PR TITLE
Support editing a blog post after creating it with -e

### DIFF
--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -63,13 +63,14 @@ module Middleman
         path_template = blog_inst.data.source_template
         params = date_to_params(@date).merge(lang: @lang.to_s, locale: @locale.to_s, title: @slug)
         article_path = apply_uri_template path_template, params
+        absolute_article_path = File.join(app.source_dir, article_path + blog_inst.options.default_extension)
 
-        template blog_inst.options.new_article_template, File.join(app.source_dir, article_path + blog_inst.options.default_extension)
+        template blog_inst.options.new_article_template, absolute_article_path
 
         if options[:edit]
           editor = ENV.fetch('MM_EDITOR', ENV.fetch('EDITOR', nil))
           if editor
-            system("#{editor} #{File.join(blog_inst.source_dir, article_path + blog_inst.options.default_extension)}")
+            system("#{editor} #{absolute_article_path}")
           else
             throw "Could not find a suitable editor. Try setting the environment variable MM_EDITOR."
           end

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -40,7 +40,6 @@ module Middleman
         @slug = safe_parameterize(title)
         @date = options[:date] ? ::Time.zone.parse(options[:date]) : Time.zone.now
         @lang = options[:lang] || options[:locale] || (::I18n.default_locale if defined? ::I18n )
-        editor = ENV['MM_EDITOR'] || ENV['EDITOR']
 
         app = ::Middleman::Application.new do
           config[:mode] = :config


### PR DESCRIPTION
Passing `-e` or `--edit` to 'middleman article' will open the user's $EDITOR
with the new blog post. It will fall back to vi if $EDITOR hasn't been exported.
(A fairly normal behaviour in Linux anyways.)

Closes #201.