### PR TITLE
Update blog_article active_support requires. Fixes #205

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'active_support/time_with_zone'
+require 'active_support/core_ext/time/acts_like'
 require 'active_support/core_ext/time/calculations'
 
 module Middleman


### PR DESCRIPTION
As far as I can tell, requiring `activesupport/core_ext/time/acts_like` keeps us from taking a bad branch at https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/date_and_time/zones.rb#L21 which leads to an exception when [calling `to_time` with a parameter](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/date_and_time/zones.rb#L36).

I wonder, though, if it might be easier just to include all the ActiveSupport Time `core_ext`s rather than cherry-pick at this granularity.
