### PR TITLE
Warn if a non-existent blog name provided for the `blog()` helper

### DIFF
--- a/lib/middleman-blog/helpers.rb
+++ b/lib/middleman-blog/helpers.rb
@@ -36,6 +36,11 @@ module Middleman
           raise "You must either specify the blog name in calling this method or in your page frontmatter (using the 'blog' blog_name)"
         end
 
+        # Warn if a non-existent blog name provided
+        if blog_name && !blog_instances.keys.include?(blog_name)
+          raise "Non-existent blog name provided: #{blog_name}."
+        end
+
         blog_name ||= blog_instances.keys.first
         blog_instances[blog_name.to_sym]
       end


### PR DESCRIPTION
Currently, if you call the `blog()` helper with an non-defined blog name, it would output the following error:

> undefined method `data' for nil:NilClass

That's pretty cryptic.

This PR makes it output this instead:

> Non-existent blog name provided: sectionsZ.

I'm sorry for not providing tests for this. I don't know how to write them properly. If you're so kind to introduce tests for this PR, i will gladly learn from them.
