### PR TITLE
Remove Nokogiri dependency by using Oga as an alternative HTML parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rspec",    "~> 2.12"
 gem "simplecov"
 
 gem "timecop",  "~> 0.6.3"
-gem "nokogiri"
+gem "oga"
 gem "kramdown"
 
 # Code Quality

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -101,7 +101,7 @@ module Middleman
 
       # The default summary generator first tries to find the +summary_separator+ and
       # take the text before it. If that doesn't work, it will truncate text without splitting
-      # the middle of an HTML tag, using a Nokogiri-based {TruncateHTML} utility.
+      # the middle of an HTML tag, using a Oga-based {TruncateHTML} utility.
       #
       # @param [String] rendered The rendered blog article
       # @param [Integer] length The length in characters to truncate to.

--- a/lib/middleman-blog/template/source/index.html.erb
+++ b/lib/middleman-blog/template/source/index.html.erb
@@ -12,7 +12,7 @@ per_page: 10
 
 <% page_articles.each_with_index do |article, i| %>
   <h2><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></h2>
-  <!-- use article.summary(250) if you have Nokogiri available to show just
+  <!-- use article.summary(250) if you have Oga available to show just
        the first 250 characters -->
   <%= article.body %>
 <% end %>


### PR DESCRIPTION
As mentioned in #105, sometimes installing Nokogiri could be the hardest part of setting up gems.

I've tried to remove Nokogiri dependency by using another html parser [Oga](https://github.com/YorickPeterse/oga) which has been introduced lately.
Although Oga is a bit still young, i thought it's worth to think about it.
