### PR TITLE
Allow rendering of BlogArticle without any layout

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -30,7 +30,7 @@ module Middleman
       # Called automatically by Middleman.
       # @return [String]
       def render(opts={}, locs={}, &block)
-        if !opts.has_key?(:layout)
+        unless opts.has_key?(:layout)
           opts[:layout] = metadata[:options][:layout]
           opts[:layout] = blog_options.layout if opts[:layout].nil?
           # Convert to a string unless it's a boolean

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -30,7 +30,7 @@ module Middleman
       # Called automatically by Middleman.
       # @return [String]
       def render(opts={}, locs={}, &block)
-        if opts[:layout].nil?
+        if !opts.has_key?(:layout)
           opts[:layout] = metadata[:options][:layout]
           opts[:layout] = blog_options.layout if opts[:layout].nil?
           # Convert to a string unless it's a boolean


### PR DESCRIPTION
`article.render` -> Render with default layout
`article.render(layout: nil)` -> Force rendering without any layout

Use case:

https://forum.middlemanapp.com/t/generate-inpage-navigation-nice-api-documentation/1002/2

When using such method to generate inpage table of content, we need to generate the html to parse it and get titles.

```ruby
def body_for(resource)
  resource.render(layout: nil)
end
```

This instruction is working fine for a standard middleman project, but when using middleman-blog, the render method is override and when specifying the layout to nil, it changes it to the default layout (which, in my case requires to generate a table of content, causing an infinite loop)

This pull request ensure that when a `layout: nil` is specified, no layout is actually used to render a BlogArticle

Is it ok for you, or should I use another process to generate my ToC?

Thank you very much