### PR TITLE
Use SourceFile#full_path for mtime in feed.xml instead of implicit to_s which doesn't work for struct.

### DIFF
--- a/lib/middleman-blog/template/source/feed.xml.builder
+++ b/lib/middleman-blog/template/source/feed.xml.builder
@@ -15,7 +15,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
       xml.id URI.join(site_url, article.url)
       xml.published article.date.to_time.iso8601
-      xml.updated File.mtime(article.source_file).iso8601
+      xml.updated File.mtime(article.source_file.full_path).iso8601
       xml.author { xml.name "Article Author" }
       # xml.summary article.summary, "type" => "html"
       xml.content article.body, "type" => "html"


### PR DESCRIPTION
Fixes #244.
