### PR TITLE
Use HTTPS to connect to rubygems.org server

### DIFF
--- a/lib/middleman-blog/template/shared/Gemfile.tt
+++ b/lib/middleman-blog/template/shared/Gemfile.tt
@@ -1,6 +1,6 @@
-# If you have OpenSSL installed, we recommend updating
-# the following line to use "https"
-source 'http://rubygems.org'
+# If you do not have OpenSSL installed, update
+# the following line to use "http://" instead
+source "https://rubygems.org"
 
 gem "middleman", "~> <%= Middleman::VERSION %>"
 gem "middleman-blog", "~> <%= Middleman::Blog::VERSION %>"


### PR DESCRIPTION
Just like the default [middleman Gemfile.tt](https://github.com/middleman/middleman/blob/d845503f5067f18d573d0dd1e35716b50e245790/middleman-core/lib/middleman-core/templates/shared/Gemfile.tt)