### PR TITLE
added viewport meta tags to enable responsiveness

### DIFF
--- a/fixtures/custom-article-template-app/source/layout.erb
+++ b/fixtures/custom-article-template-app/source/layout.erb
@@ -3,18 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv='X-UA-Compatible' content='IE=edge;chrome=1' />
-    
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <% if is_blog_article? %>
       <title><%= current_article.title %></title>
     <% end %>
   </head>
   <body>
-    
+
     <div id="main" role="main">
       <% if is_blog_article? %>
         <article class="hentry">
           <h1 class="entry-title">
-            <%= current_article.title %> 
+            <%= current_article.title %>
             <time class="updated"><%= current_article.date.strftime('%b %e %Y') %></time>
           </h1>
 

--- a/fixtures/default-template-app/source/layouts/layout.erb
+++ b/fixtures/default-template-app/source/layouts/layout.erb
@@ -5,6 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
   <title><%= page_title %></title>
   <%= javascript_include_tag :modernizr %>
   <%= stylesheet_link_tag :app %>
@@ -44,7 +46,7 @@
         <div class="large-12 columns">
           <time class="updated"><%= current_article.date.strftime('%b %e %Y') %></time>
           <h1 class="entry-title">
-            <%= current_article.title %> 
+            <%= current_article.title %>
           </h1>
 
           <div class="entry-content">

--- a/fixtures/multiblog-app/source/layout.erb
+++ b/fixtures/multiblog-app/source/layout.erb
@@ -3,18 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv='X-UA-Compatible' content='IE=edge;chrome=1' />
-    
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <% if is_blog_article? %>
       <title><%= current_article.title %></title>
     <% end %>
   </head>
   <body>
-    
+
     <div id="main" role="main">
       <% if is_blog_article? %>
         <article class="hentry">
           <h1 class="entry-title">
-            <%= current_article.title %> 
+            <%= current_article.title %>
             <time class="updated"><%= current_article.date.strftime('%b %e %Y') %></time>
           </h1>
 

--- a/fixtures/preview-app/source/layout.erb
+++ b/fixtures/preview-app/source/layout.erb
@@ -3,18 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv='X-UA-Compatible' content='IE=edge;chrome=1' />
-    
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <% if is_blog_article? %>
       <title><%= current_article.title %></title>
     <% end %>
   </head>
   <body>
-    
+
     <div id="main" role="main">
       <% if is_blog_article? %>
         <article class="hentry">
           <h1 class="entry-title">
-            <%= current_article.title %> 
+            <%= current_article.title %>
             <time class="updated"><%= current_article.date.strftime('%b %e %Y') %></time>
           </h1>
 


### PR DESCRIPTION
I had trouble figuring out why my navbar wasn't collapsing on mobile, until I realised the template was just missing the meta tag enabling to do so.
Also removed some extra spaces.