### PR TITLE
Fix article summaries

### DIFF
--- a/features/summary.feature
+++ b/features/summary.feature
@@ -2,9 +2,9 @@ Feature: Article summary generation
   Scenario: Article has no summary separator
     Given the Server is running at "summary-app"
     When I go to "/index.html"
-    Then I should see "Summary from article with separator."
+    Then I should see "<p>Summary from article with separator.</p>"
     Then I should not see "Extended part from article with separator."
-    Then I should see "Summary from article with no separator."
+    Then I should see "<p>Summary from article with no separator.</p>"
     Then I should not see "Extended part from article with no separator."
 
   Scenario: Article has custom summary separator
@@ -17,7 +17,11 @@ Feature: Article summary generation
       """
     Given the Server is running at "summary-app"
     When I go to "/index.html"
-    Then I should see "Summary from article with custom separator."
+    Then I should see:
+      """
+      <p>Summary from article with custom separator.
+      </p>
+      """
     Then I should not see "Extended part from article with custom separator."
     Then I should see "Extended part from article with separator."
 

--- a/features/summary.feature
+++ b/features/summary.feature
@@ -32,7 +32,7 @@ Feature: Article summary generation
     Given the Server is running at "summary-app"
     When I go to "/index.html"
     Then I should see "This is my summary, and I like it"
-    Then I should see "Summary from article"
+    Then I should not see "Summary from article"
     Then I should not see "Summary from article with no separator"
     Then I should not see "Extended part from article"
 

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -73,16 +73,16 @@ module Middleman
         render layout: false
       end
 
-      # The summary for this article, in HTML. The summary is either
-      # everything before the summary separator (set via the blog option
-      # +summary_separator+ and defaulting to "READMORE") or the first
-      # +summary_length+ characters of the post.
+      # The summary for this article, in HTML.
       #
       # The blog option +summary_generator+ can be set to a +Proc+ in order to provide
       # custom summary generation. The +Proc+ is provided
       # the rendered content of the article (without layout), the
       # desired length to trim the summary to, and the ellipsis string to use.
-      # Otherwise the {#default_summary_generator} will be used.
+      # Otherwise the {#default_summary_generator} will be used, which returns either
+      # everything before the summary separator (set via the blog option
+      # +summary_separator+ and defaulting to "READMORE") if it is found,
+      # or the first +summary_length+ characters of the post.
       #
       # @param [Number] length How many characters to trim the summary to.
       # @param [String] ellipsis The ellipsis string to use when content is trimmed.
@@ -90,9 +90,7 @@ module Middleman
       def summary(length=blog_options.summary_length, ellipsis='...')
         rendered = render layout: false, keep_separator: true
 
-        if blog_options.summary_separator && rendered.match(blog_options.summary_separator)
-          rendered.split(blog_options.summary_separator).first
-        elsif blog_options.summary_generator
+        if blog_options.summary_generator
           blog_options.summary_generator.call(self, rendered, length, ellipsis)
         else
           default_summary_generator(rendered, length, ellipsis)

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -105,11 +105,12 @@ module Middleman
       # @param [Integer] length The length in characters to truncate to.
       #   -1 or +nil+ will return the whole article.
       def default_summary_generator(rendered, length, ellipsis)
-        if blog_options.summary_separator && rendered =~ blog_options.summary_separator
-          rendered.split(blog_options.summary_separator).first
+        if blog_options.summary_separator && rendered.match(blog_options.summary_separator)
+          require 'middleman-blog/truncate_html'
+          TruncateHTML.truncate_at_separator(rendered, blog_options.summary_separator)
         elsif length && length >= 0
           require 'middleman-blog/truncate_html'
-          TruncateHTML.truncate_html(rendered, length, ellipsis)
+          TruncateHTML.truncate_at_length(rendered, length, ellipsis)
         else
           rendered
         end

--- a/lib/middleman-blog/truncate_html.rb
+++ b/lib/middleman-blog/truncate_html.rb
@@ -7,7 +7,18 @@ end
 # Taken and modified from http://madebydna.com/all/code/2010/06/04/ruby-helper-to-cleanly-truncate-html.html
 # MIT license
 module TruncateHTML
-  def self.truncate_html(text, max_length, ellipsis = "...")
+  def self.truncate_at_separator(text, separator)
+    text = text.encode('UTF-8') if text.respond_to?(:encode)
+    doc = Nokogiri::HTML::DocumentFragment.parse text
+    length = doc.inner_text =~ Regexp.new(separator)
+    if length
+      doc.truncate(length - 1, '').inner_html
+    else
+      text
+    end
+  end
+
+  def self.truncate_at_length(text, max_length, ellipsis = "...")
     ellipsis_length = ellipsis.length
     text = text.encode('UTF-8') if text.respond_to?(:encode)
     doc = Nokogiri::HTML::DocumentFragment.parse text


### PR DESCRIPTION
I noticed that article summaries create invalid HTML when a`summary_separator` is used (#265) yet not when `summary_length` is used. The reason is that Nokogiri is used in the latter case yet when the separator is defined, the HTML is simply truncated.

This PR fixes this, so that Nokogiri is used to create a summary using a separator as well.

While implementing this, I noticed that a defined `summary_generator` is ignored when the `summary_separator` is found, which I can't imagine is the intended behaviour.

I implemented the `truncate_at_separator` method as a separate method which creates a bit of duplication. We could merge it with `truncate_at_length` but I'm not sure how clean it would be...