### PR TITLE
Filter articles for locale

### DIFF
--- a/lib/middleman-blog/paginator.rb
+++ b/lib/middleman-blog/paginator.rb
@@ -33,7 +33,10 @@ module Middleman
           # "articles" local variable is populated by Calendar and Tag page generators
           # If it's not set then use the complete list of articles
           # TODO: Some way to allow the frontmatter to specify the article filter?
-          articles = md[:locals]["articles"] || @blog_controller.data.articles
+          all_articles = (md[:locals]["articles"] || @blog_controller.data.articles)
+          articles = all_articles.select do |article|
+            article.lang == I18n.locale
+          end
 
           # Allow blog.per_page and blog.page_link to be overridden in the frontmatter
           per_page  = md[:page][:per_page] || @per_page

--- a/lib/middleman-blog/paginator.rb
+++ b/lib/middleman-blog/paginator.rb
@@ -34,9 +34,14 @@ module Middleman
           # If it's not set then use the complete list of articles
           # TODO: Some way to allow the frontmatter to specify the article filter?
           all_articles = (md[:locals]["articles"] || @blog_controller.data.articles)
-          articles = all_articles.select do |article|
-            article.lang == I18n.locale
-          end
+          articles = 
+            if @app.extensions.instance_variable_get(:@activated)[:i18n]
+              all_articles.select do |article|
+                article.lang == I18n.locale
+              end
+            else
+              all_articles
+            end
 
           # Allow blog.per_page and blog.page_link to be overridden in the frontmatter
           per_page  = md[:page][:per_page] || @per_page


### PR DESCRIPTION
There seems to be no `activated?` method, unfortunately, to check whether an extension is enabled
or not.
It there another way to check whether multi-language support is enabled ?