### PR TITLE
Add filter option

### DIFF
--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -8,6 +8,8 @@ module Middleman
     class BlogData
       include UriTemplates
 
+      DEFAULT_FILTER = proc {|a| a}
+
       # A URITemplate for the source file path relative to :source_dir
       # @return [URITemplate]
       attr_reader :source_template
@@ -36,7 +38,7 @@ module Middleman
       # A list of all blog articles, sorted by descending date
       # @return [Array<Middleman::Sitemap::Resource>]
       def articles
-        @_articles.sort_by(&:date).reverse
+        @_articles.select(&(options.filter || DEFAULT_FILTER)).sort_by(&:date).reverse
       end
 
       # A list of all blog articles with the given language,

--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -34,6 +34,7 @@ module Middleman
     option :generate_tag_pages, true, 'Whether to generate tag pages.'
     option :paginate, false, 'Whether to paginate lists of articles'
     option :per_page, 10, 'Number of articles per page when paginating'
+    option :filter, nil, 'A proc that can be used to select articles that should be published based on user-defined criteria'
     option :page_link, 'page/{num}', 'Path to append for additional pages when paginating'
     option :publish_future_dated, false, 'Whether articles with a date in the future should be considered published'
     option :custom_collections, {}, 'Hash of custom frontmatter properties to collect articles on and their options (link, template)'


### PR DESCRIPTION
This adds a `filter` option that can be used to select certain articles for publishing; without
confusing the paginator.

As an example, the problem that in a multi-language setting articles of all the languages appear on
a blog, irrespective of the current page locale, can now relatively elegantly be solved as follows:
```ruby
activate :blog do |blog|
  blog.name = "blog"
  blog.filter = proc {|article| article.locale == I18n.locale }
  blog.paginate = true
end
```