### PR TITLE
Fix summary generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'pry', '~> 0.10', group: :development, require: false
 gem 'aruba', '~> 0.7.4', require: false
 gem 'rspec', '~> 3.0', require: false
 gem 'cucumber', '~> 2.0', require: false
+gem 'capybara', require: false # middleman-core forces all plugins to declare this
 
 gem "timecop",  "~> 0.6.3"
 gem "nokogiri"

--- a/features/summary.feature
+++ b/features/summary.feature
@@ -2,7 +2,11 @@ Feature: Article summary generation
   Scenario: Article has no summary separator
     Given the Server is running at "summary-app"
     When I go to "/index.html"
-    Then I should see "<p>Summary from article with separator.</p>"
+    Then I should see:
+      """
+      <p>Summary from article with separator.
+      </p>
+      """
     Then I should not see "Extended part from article with separator."
     Then I should see "<p>Summary from article with no separator.</p>"
     Then I should not see "Extended part from article with no separator."
@@ -23,6 +27,24 @@ Feature: Article summary generation
       </p>
       """
     Then I should not see "Extended part from article with custom separator."
+    Then I should see "Extended part from article with separator."
+
+  Scenario: Article has custom summary separator that's an HTML comment
+    Given a fixture app "summary-app"
+    And a file named "config.rb" with:
+      """
+      activate :blog do |blog|
+        blog.summary_separator = /<!--more-->/
+      end
+      """
+    Given the Server is running at "summary-app"
+    When I go to "/index.html"
+    Then I should see:
+      """
+      <p>Summary from article with HTML comment separator.
+      </p>
+      """
+    Then I should not see "Extended part from article with HTML comment separator."
     Then I should see "Extended part from article with separator."
 
   Scenario: Using a custom summary generator
@@ -79,4 +101,6 @@ Feature: Article summary generation
     Then I should see "Summary1"
     Then I should see "Summary2"
     Then I should see "Summary3"
-    Then I should see "Summary4"
+    # it has a custom separator, which overrides explicit length, so we show up to the separator
+    Then I should see "Summary from article with separator."
+    Then I should see "Summary5"

--- a/fixtures/summary-app/source/2013-05-08-article-with-custom-separator.html.markdown
+++ b/fixtures/summary-app/source/2013-05-08-article-with-custom-separator.html.markdown
@@ -3,5 +3,5 @@ title: "Article with custom summary separator"
 ---
 
 Summary from article with custom separator.
-/SPLIT_SUMMARY_BEFORE_THIS/
+SPLIT_SUMMARY_BEFORE_THIS
 Extended part from article with custom separator.

--- a/fixtures/summary-app/source/2016-05-21-article-with-comment-separator.html.markdown
+++ b/fixtures/summary-app/source/2016-05-21-article-with-comment-separator.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "Article with HTML comment summary separator"
+---
+
+Summary from article with HTML comment separator.
+<!--more-->
+Extended part from article with HTML comment separator.

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -104,13 +104,14 @@ module Middleman
       # @param [String] rendered The rendered blog article
       # @param [Integer] length The length in characters to truncate to.
       #   -1 or +nil+ will return the whole article.
+      # @param [String] ellipsis The ellipsis string to use when content is trimmed.
       def default_summary_generator(rendered, length, ellipsis)
-        if length && length >= 0
-          require 'middleman-blog/truncate_html'
-          TruncateHTML.truncate_at_length(rendered, length, ellipsis)
-        elsif blog_options.summary_separator && rendered.match(blog_options.summary_separator)
+        if blog_options.summary_separator && rendered.match(blog_options.summary_separator)
           require 'middleman-blog/truncate_html'
           TruncateHTML.truncate_at_separator(rendered, blog_options.summary_separator)
+        elsif length && length >= 0
+          require 'middleman-blog/truncate_html'
+          TruncateHTML.truncate_at_length(rendered, length, ellipsis)
         elsif blog_options.summary_length && blog_options.summary_length > 0
           require 'middleman-blog/truncate_html'
           TruncateHTML.truncate_at_length(rendered, blog_options.summary_length, ellipsis)

--- a/lib/middleman-blog/truncate_html.rb
+++ b/lib/middleman-blog/truncate_html.rb
@@ -9,13 +9,8 @@ end
 module TruncateHTML
   def self.truncate_at_separator(text, separator)
     text = text.encode('UTF-8') if text.respond_to?(:encode)
-    doc = Nokogiri::HTML::DocumentFragment.parse text
-    length = doc.inner_text =~ Regexp.new(separator)
-    if length
-      doc.truncate(length - 1, '').inner_html
-    else
-      text
-    end
+    doc = Nokogiri::HTML::DocumentFragment.parse text.split(separator).first
+    doc.inner_html
   end
 
   def self.truncate_at_length(text, max_length, ellipsis = "...")
@@ -24,7 +19,7 @@ module TruncateHTML
     doc = Nokogiri::HTML::DocumentFragment.parse text
     content_length = doc.inner_text.length
     actual_length = max_length - ellipsis_length
-    if content_length > actual_length 
+    if content_length > actual_length
       doc.truncate(actual_length, ellipsis).inner_html
     else
       text


### PR DESCRIPTION
This fixes #279. Now summary is always shown up to the separator even when a length is specified, and separators that are HTML comments also work. Tests have been modified to reflect this desired behavior.