### PR TITLE
Fix article subdirectory files when used with directory_indexes

### DIFF
--- a/features/article_dirs.feature
+++ b/features/article_dirs.feature
@@ -5,3 +5,14 @@ Feature: Article-specific subdirectories
     Then I should see "Not Found"
     When I go to "/2011/01/01/new-article/example.txt"
     Then I should see "Example Text"
+
+  Scenario: Blog articles with directory_indexes can have their own subdirectories for related files
+    Given a fixture app "article-dirs-app"
+    And app "calendar-app" is using config "directory-indexes"
+    And the Server is running
+    When I go to "/2011/01/01/new-article"
+    Then I should see "Newer Article Content"
+    When I go to "/2011-01-01-new-article/example.txt"
+    Then I should see "Not Found"
+    When I go to "/2011/01/01/new-article/example.txt"
+    Then I should see "Example Text"

--- a/features/article_dirs.feature
+++ b/features/article_dirs.feature
@@ -16,3 +16,14 @@ Feature: Article-specific subdirectories
     Then I should see "Not Found"
     When I go to "/2011/01/01/new-article/example.txt"
     Then I should see "Example Text"
+
+  Scenario: Blog articles with permalinks containing dots can have their own subdirectories for related files
+    Given a fixture app "article-dirs-app"
+    And app "article-dirs-app" is using config "permalink-with-dot"
+    And the Server is running
+    When I go to "/2011.01.01/new-article"
+    Then I should see "Newer Article Content"
+    When I go to "/2011-01-01-new-article/example.txt"
+    Then I should see "Not Found"
+    When I go to "/2011.01.01/new-article/example.txt"
+    Then I should see "Example Text"

--- a/features/article_dirs.feature
+++ b/features/article_dirs.feature
@@ -8,7 +8,7 @@ Feature: Article-specific subdirectories
 
   Scenario: Blog articles with directory_indexes can have their own subdirectories for related files
     Given a fixture app "article-dirs-app"
-    And app "calendar-app" is using config "directory-indexes"
+    And app "article-dirs-app" is using config "directory-indexes"
     And the Server is running
     When I go to "/2011/01/01/new-article"
     Then I should see "Newer Article Content"

--- a/fixtures/article-dirs-app/config-directory-indexes.rb
+++ b/fixtures/article-dirs-app/config-directory-indexes.rb
@@ -1,0 +1,6 @@
+activate :blog do |blog|
+  blog.permalink = "{year}/{month}/{day}/{title}"
+  blog.sources = "blog/:year-:month-:day-:title.html"
+end
+
+activate :directory_indexes

--- a/fixtures/article-dirs-app/config-permalink-with-dot.rb
+++ b/fixtures/article-dirs-app/config-permalink-with-dot.rb
@@ -1,0 +1,6 @@
+activate :blog do |blog|
+  blog.permalink = "{year}.{month}.{day}/{title}"
+  blog.sources = "blog/:year-:month-:day-:title.html"
+end
+
+activate :directory_indexes

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -37,7 +37,7 @@ module Middleman
         @source_template = uri_template options.sources
         @permalink_template = uri_template options.permalink
         @subdir_template = uri_template options.sources.sub(/\.[^.]+$/, "/{+path}")
-        @subdir_permalink_template = uri_template options.permalink.sub(/\.[^.]+$/, "/{+path}")
+        @subdir_permalink_template = uri_template options.permalink.sub(/(\.[^.]+)?$/, "/{+path}")
       end
 
       # A list of all blog articles, sorted by descending date

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -36,8 +36,8 @@ module Middleman
 
         @source_template = uri_template options.sources
         @permalink_template = uri_template options.permalink
-        @subdir_template = uri_template options.sources.sub(/\.[^.]+$/, "/{+path}")
-        @subdir_permalink_template = uri_template options.permalink.sub(/(\.[^.]+)?$/, "/{+path}")
+        @subdir_template = uri_template options.sources.sub(/(\.[^.{}\/]+)?$/, "/{+path}")
+        @subdir_permalink_template = uri_template options.permalink.sub(/(\.[^.{}\/]+)?$/, "/{+path}")
       end
 
       # A list of all blog articles, sorted by descending date


### PR DESCRIPTION
When directory_indexes is used along with a permalink without a file extension (e.g., "{year}/{month}/{day}/{title}") and subdirectory files exist, the current behavior causes the first subdirectory file to be written to the (permalink) path that should be used for the article itself.

Specifically, when the permalink has no file extension, then `@subdir_permalink_template` ends up missing the `{+path}` element (https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/blog_data.rb#L40), meaning that the output path doesn't include the relative filename.

I'm not 100% sure what the best solution is, but this attempts to fix it by optionally matching an extension (if it exists) with the regular expression, though it will still make the substitution at the end of the permalink either way.