### PR TITLE
fixes #182 - i18n based blog pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .sass-cache
 coverage
 .byebug_history
+bin/

--- a/lib/middleman-blog/paginator.rb
+++ b/lib/middleman-blog/paginator.rb
@@ -34,6 +34,7 @@ module Middleman
           # If it's not set then use the complete list of articles
           # TODO: Some way to allow the frontmatter to specify the article filter?
           articles = md[:locals]["articles"] || @blog_controller.data.articles
+          articles.select!{|article| article.lang == md[:options][:locale]} if md.fetch(:options, false) and md[:options].fetch(:locale, false)
 
           # Allow blog.per_page and blog.page_link to be overridden in the frontmatter
           per_page  = md[:page][:per_page] || @per_page


### PR DESCRIPTION
i18n based blog pagination was not working properly. I've just added:

```ruby
articles.select!{|article| article.lang == md[:options][:locale]} if md.fetch(:options, false) and md[:options].fetch(:locale, false)
```

to `paginator.rb` line 37 :)