### PR TITLE
Fix `middleman article` command for multiple blogs

### DIFF
--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -44,7 +44,7 @@ module Middleman
         end
 
         blog_inst = if options[:blog]
-          app.extensions[:blog].find { |key, instance| instance.options[:name] == options[:blog] }[key]
+          app.extensions[:blog].find { |key, instance| instance.options[:name] == options[:blog] }[1]
         else
           app.extensions[:blog].values.first
         end

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -44,7 +44,7 @@ module Middleman
         end
 
         blog_inst = if options[:blog]
-          app.extensions[:blog][options[:blog]]
+          app.extensions[:blog].find { |key, instance| instance.options[:name] == options[:blog] }[key]
         else
           app.extensions[:blog].values.first
         end


### PR DESCRIPTION
The `middleman article` command presumed the key name for the blog is the same as the blog name; its not. Rather than getting the blog by key, this finds it by name.