### PR TITLE
Generating a blog article can optional create article subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pkg/*
 .DS_Store
 .rbenv-version
 .ruby-version
+.ruby-gemset
 tmp
 doc
 .yardoc

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -35,6 +35,11 @@ module Middleman
         desc: "Edit the newly created blog post",
         default: false,
         type: :boolean
+      class_option "subdirectory",
+        aliases: "-s",
+        desc: "Generate an article subdirectory (for directory indexes, defaults to false)",
+        default: false,
+        type: :boolean
       def article
         @title = title
         @slug = safe_parameterize(title)
@@ -66,6 +71,10 @@ module Middleman
         absolute_article_path = File.join(app.source_dir, article_path + blog_inst.options.default_extension)
 
         template blog_inst.options.new_article_template, absolute_article_path
+
+        if options[:subdirectory]
+          empty_directory extract_directory_path(File.join(app.source_dir, article_path))
+        end
 
         if options[:edit]
           editor = ENV.fetch('MM_EDITOR', ENV.fetch('EDITOR', nil))

--- a/lib/middleman-blog/uri_templates.rb
+++ b/lib/middleman-blog/uri_templates.rb
@@ -78,6 +78,13 @@ module Middleman
           day: date.day.to_s.rjust(2,'0')
         }
       end
+
+      def extract_directory_path(article_path)
+        uri = Addressable::URI.parse article_path
+
+        # Remove file extension from the article path
+        directory_path = uri.path.gsub(uri.extname, '')
+      end
     end
 
     # A special template processor that validates date fields

--- a/spec/uri_templates_spec.rb
+++ b/spec/uri_templates_spec.rb
@@ -61,4 +61,16 @@ describe 'Middleman::Blog::UriTemplates' do
       expect(params['path']) == 'foo/bar.html'
     end
   end
+
+  describe 'extract_directory_path' do
+
+    it 'can extract a directory path' do
+      template = uri_template('{year}/{month}/{day}/{title}/{+path}')
+      params = extract_params(template, '2013/12/13/foo-bar/foo/bar.html')
+      article_path = apply_uri_template template, params
+
+      expect(extract_directory_path(article_path)) == '2013-12-13-foo-bar-foo-bar'
+    end
+
+  end
 end


### PR DESCRIPTION
When Middleman's `directory_indexes` have been turned on for friendly urls and leveraging [Article Subdirectories](https://middlemanapp.com/basics/blogging/#article-subdirectory) - generating an article via the middleman blog command only creates the article file.  

This pull-request adds a new option to the middleman blog command to generate a new article and create the matching article subdirectory so a user doesn't have to manual create it and worry about typos.
