### PR TITLE
Format-insensitive tagging-V3

### DIFF
--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -57,6 +57,7 @@ module Middleman
         tags = {}
         @_articles.each do |article|
           article.tags.each do |tag|
+            tag = safe_parameterize(tag)
             tags[tag] ||= []
             tags[tag] << article
           end

--- a/lib/middleman-blog/tag_pages.rb
+++ b/lib/middleman-blog/tag_pages.rb
@@ -36,11 +36,15 @@ module Middleman
         Sitemap::Resource.new(@sitemap, link(tag)).tap do |p|
           p.proxy_to(@tag_template)
 
+          # Detect "formated" tag in first article - trying to
+          # guess the correct format to show
+          tagname = articles.first.tags.detect { |article_tag| safe_parameterize(article_tag) == tag }
+
           # Add metadata in local variables so it's accessible to
           # later extensions
           p.add_metadata locals: {
             'page_type' => 'tag',
-            'tagname' => tag,
+            'tagname' => tagname,
             'articles' => articles,
             'blog_controller' => @blog_controller
           }


### PR DESCRIPTION
Cluster articles by "URL safe" version of tags, so we don't miss articles in listings.

Fix for `v3-stable` branch.

Fixes middleman/middleman-blog#313
