### PR TITLE
Format-insensitive tagging-V4

### DIFF
--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -98,6 +98,7 @@ module Middleman
 
           # Reference the tags assigned to an article
           article.tags.each do |tag|
+            tag = safe_parameterize(tag)
             tags[tag] ||= []
             tags[tag] << article
           end

--- a/lib/middleman-blog/tag_pages.rb
+++ b/lib/middleman-blog/tag_pages.rb
@@ -71,6 +71,9 @@ module Middleman
           # Detect "formated" tag in first article - trying to
           # guess the correct format to show
           tagname = articles.first.tags.detect { |article_tag| safe_parameterize(article_tag) == tag }
+          if different_article = articles.find { |article| article.tags.detect { |article_tag| safe_parameterize(article_tag) == tagname && article_tag != tagname } }
+            raise "Article #{different_article.path} has tag #{tagname} with a different spelling - fix it to avoid misstagging (see middleman/middleman-blog#313)"
+          end
 
           # Add metadata in local variables so it's accessible to
           # later extensions

--- a/lib/middleman-blog/tag_pages.rb
+++ b/lib/middleman-blog/tag_pages.rb
@@ -68,11 +68,15 @@ module Middleman
 
         Sitemap::ProxyResource.new( @sitemap, link( tag ), @tag_template ).tap do | p |
 
+          # Detect "formated" tag in first article - trying to
+          # guess the correct format to show
+          tagname = articles.first.tags.detect { |article_tag| safe_parameterize(article_tag) == tag }
+
           # Add metadata in local variables so it's accessible to
           # later extensions
           p.add_metadata locals: {
             'page_type'       => 'tag',
-            'tagname'         => tag,
+            'tagname'         => tagname,
             'articles'        => articles,
             'blog_controller' => @blog_controller
           }


### PR DESCRIPTION
Cluster articles by "URL safe" version of tags, so we don't miss articles in listings.

Fix for `master` branch.

Fixes middleman/middleman-blog#313
