### PR TITLE
Tags should honor filter option

### DIFF
--- a/features/tags.feature
+++ b/features/tags.feature
@@ -95,3 +95,12 @@ Feature: Tag pages
     | tags/bar.html |
 
     And the file "index.html" should contain "Tag Path: ''"
+
+  Scenario: Tags respect filters
+    Given a fixture app "tags-app"
+    And app "tags-app" is using config "filters"
+    And the Server is running
+
+    When I go to "/tags/foo.html"
+    Then I should see "/2011-01-01-new-article.html"
+    Then I should not see "/2011-01-02-another-article.html"

--- a/fixtures/tags-app/config-filters.rb
+++ b/fixtures/tags-app/config-filters.rb
@@ -1,0 +1,7 @@
+require "middleman-blog"
+activate :blog do |blog|
+  blog.sources      = "blog/:year-:month-:day-:title.html"
+  blog.permalink    = "blog/:year-:month-:day-:title.html"
+  blog.tag_template = "/tag.html"
+  blog.filter       = proc {|article| !article.title.start_with?("Another") }
+end

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -83,16 +83,11 @@ module Middleman
       def tags
         tags = {}
 
-        @_articles.each do |article|
+        articles.each do |article|
           article.tags.each do |tag|
             tags[tag] ||= []
             tags[tag] << article
           end
-        end
-
-        # Sort each tag's list of articles
-        tags.each do |tag, articles|
-          tags[tag] = articles.sort_by(&:date).reverse
         end
 
         tags


### PR DESCRIPTION
This PR causes the tags feature to honor the `filter` option, i.e., only include articles that are in the main list.

The sorting block was removed, as `articles` sorts the list already.
