### PR TITLE
Can set article tags at `middleman article` command

### DIFF
--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -25,6 +25,9 @@ module Middleman
       class_option "tags",
         aliases: "-t",
         desc: "A list of comma-separated tags for the post"
+      class_option "content",
+        aliases: "-c",
+        desc: "Content of the post"
       class_option "lang",
         desc: "Deprecated, use locale"
       class_option "locale",
@@ -44,7 +47,7 @@ module Middleman
         @date = options[:date] ? ::Time.zone.parse(options[:date]) : Time.zone.now
         @lang = options[:lang] || options[:locale] || (::I18n.default_locale if defined? ::I18n )
         @tags = options[:tags].split(/\s*,\s*/)
-
+        @content = options[:content] || ""
         app = ::Middleman::Application.new do
           config[:mode] = :config
           config[:disable_sitemap] = true

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -46,7 +46,7 @@ module Middleman
         @slug = safe_parameterize(title)
         @date = options[:date] ? ::Time.zone.parse(options[:date]) : Time.zone.now
         @lang = options[:lang] || options[:locale] || (::I18n.default_locale if defined? ::I18n )
-        @tags = options[:tags].split(/\s*,\s*/)
+        @tags = options[:tags] && options[:tags].split(/\s*,\s*/) || []
         @content = options[:content] || ""
         app = ::Middleman::Application.new do
           config[:mode] = :config

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -22,6 +22,9 @@ module Middleman
       class_option "date",
         aliases: "-d",
         desc: "The date to create the post with (defaults to now)"
+      class_option "tags",
+        aliases: "-t",
+        desc: "A list of comma-separated tags for the post"
       class_option "lang",
         desc: "Deprecated, use locale"
       class_option "locale",
@@ -40,6 +43,7 @@ module Middleman
         @slug = safe_parameterize(title)
         @date = options[:date] ? ::Time.zone.parse(options[:date]) : Time.zone.now
         @lang = options[:lang] || options[:locale] || (::I18n.default_locale if defined? ::I18n )
+        @tags = options[:tags].split(/\s*,\s*/)
 
         app = ::Middleman::Application.new do
           config[:mode] = :config

--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -46,7 +46,7 @@ module Middleman
         @slug = safe_parameterize(title)
         @date = options[:date] ? ::Time.zone.parse(options[:date]) : Time.zone.now
         @lang = options[:lang] || options[:locale] || (::I18n.default_locale if defined? ::I18n )
-        @tags = options[:tags] && options[:tags].split(/\s*,\s*/) || []
+        @tags = options[:tags] && options[:tags].split(/\s*,\s*/) || self.title.split(/[\s_-]/).reject { |w| w.empty? }
         @content = options[:content] || ""
         app = ::Middleman::Application.new do
           config[:mode] = :config

--- a/lib/middleman-blog/commands/article.tt
+++ b/lib/middleman-blog/commands/article.tt
@@ -1,6 +1,6 @@
 ---
 title: <%= @title %>
 date: <%= @date.strftime('%F %R %Z') %>
-tags:
+tags: <%= @tags.join(",") %>
 ---
 

--- a/lib/middleman-blog/commands/article.tt
+++ b/lib/middleman-blog/commands/article.tt
@@ -4,3 +4,4 @@ date: <%= @date.strftime('%F %R %Z') %>
 tags: <%= @tags.join(",") %>
 ---
 
+<%= @content %>


### PR DESCRIPTION
Could this be useful?

when `middleman article awesome-article -t foo,bar` the created article already has given tags in the frontmatter.
