### PR TITLE
Unexpected escape to unicode(also multibyte language) charcter for tag output.

### DIFF
--- a/features/tags.feature
+++ b/features/tags.feature
@@ -129,3 +129,15 @@ Feature: Tag pages
     When I go to "/tags/foo.html"
     Then I should see "/2011-01-01-new-article.html"
     Then I should not see "/2011-01-02-another-article.html"
+
+  Scenario: Tag pages are accessible from preview server with unicode character.
+
+    Given the Server is running at "tags-app"
+
+    When I go to "/tags/テスト.html"
+    Then I should see "/2011-01-04-i18n-tags.html"
+    Then I should see "Tag: テスト"
+
+    When I go to "/tags/きゅうり.html"
+    Then I should see "/2011-01-04-i18n-tags.html"
+    Then I should see "Tag: きゅうり"

--- a/fixtures/tags-app/source/blog/2011-01-04-i18n-tags.html.markdown
+++ b/fixtures/tags-app/source/blog/2011-01-04-i18n-tags.html.markdown
@@ -1,0 +1,7 @@
+---
+title: "Newer Article"
+date: 2011-01-04
+tags: テスト, きゅうり
+---
+
+Newer Article Content


### PR DESCRIPTION
Hello, I encountered unexpected escape to unicode character on tag function. I created cucumber feature of my issue. It happens at v4.0.2. v4.0.1 is not affected.

Is it intentional behavior?