### PR TITLE
Binary awesomeness

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -295,6 +295,37 @@ module Middleman
         article_next()
       end
       deprecate :next_article, :article_next, 2017, 5
+      
+      def binary_search(array, value, from=0, to=nil)
+        publish_date = value.date
+        to = array.count - 1 if to == nil
+      
+        # from can't be bigger than to
+        raise ArgumentError if from > to
+      
+        # out of range
+        raise ArgumentError if from < 0
+        raise ArgumentError if to >= array.count
+        while true do
+          mid = (from + to) / 2
+          comparison = publish_date <=> array[mid].date
+          # not found
+          return -1 if from == to && comparison != 0
+      
+          case comparison
+          when 0 
+            if array[mid] == value
+              return mid
+            else
+              return array[from..to].find_index(value) + from
+            end
+          when 1 
+            to = mid - 1
+          when -1 
+            from = mid + 1
+          end
+        end    
+      end
 
       ##
       # The previous (chronologically earlier) article before this one or
@@ -303,7 +334,11 @@ module Middleman
       # @return [BlogArticle]
       ##
       def article_previous
-        blog_data.articles.find { |a| a.date < self.date }
+        articles = blog_data.articles
+        idx = binary_search(articles, self)
+        nextIdx = idx+1
+        return nil if nextIdx >= articles.count
+        return articles[nextIdx]
       end
 
       ##
@@ -313,7 +348,10 @@ module Middleman
       # @return [Middleman::Sitemap::Resource]
       ##
       def article_next
-        blog_data.articles.reverse.find { |a| a.date > self.date }
+        articles = blog_data.articles
+        idx = binary_search(articles, self)
+        return nil if idx <= 0
+        return articles[idx-1]
       end
 
       ##

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -34,6 +34,7 @@ module Middleman
 
         # A list of resources corresponding to blog articles
         @_articles = []
+        @_sorted_articles = []
 
         @_parsed_url_cache = {
           source: {},
@@ -52,7 +53,11 @@ module Middleman
       # @return [Array<Middleman::Sitemap::Resource>]
       ##
       def articles
-        @_articles.select( &( options.filter || proc { | a | a } ) ).sort_by( &:date ).reverse
+        if @_sorted_articles.empty?
+          @_sorted_articles = @_articles.select( &( options.filter || proc { | a | a } ) ).sort_by( &:date ).reverse
+          @_sorted_articles.freeze
+        end
+        @_sorted_articles
       end
 
       ##
@@ -130,6 +135,7 @@ module Middleman
       ##
       def manipulate_resource_list(resources)
         @_articles = []
+        @_sorted_articles = []
         used_resources = []
 
         resources.each do |resource|


### PR DESCRIPTION
This patch caches the sorted articles so to do it only once.
In my synthetic benchmark (generated ~1500 articles with a lorem ipsum content)
It went from 108 seconds to 88

`bundle exec middleman build  88.71s user 3.49s system 273% cpu 33.764 total`
`bundle exec middleman build  108.48s user 4.03s system 265% cpu 42.429 total`

I no longer use middleman-blog but found this while researching for https://github.com/middleman/middleman/issues/2105