### PR TITLE
Title should be always a string

### DIFF
--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -76,7 +76,7 @@ module Middleman
       # @return [String]
       ##
       def title
-        data['title']
+        data['title'].to_s
       end
 
       ##


### PR DESCRIPTION
Even when the author put in a number

Found this bug while creating the benchmark for https://github.com/middleman/middleman-blog/pull/350