### PR TITLE
Add support for environments

### DIFF
--- a/lib/middleman-blog/commands/article.rb
+++ b/lib/middleman-blog/commands/article.rb
@@ -64,7 +64,13 @@ module Middleman
         aliases: "-t",
         desc: "A list of comma-separated tags for the post"
 
+      class_option "environment",
+        desc: "The environment to generate article for",
+        default: ENV['MM_ENV'] || ENV['RACK_ENV'] || 'development',
+        type: :string
+
       def article
+        env = options[:environment].to_s.to_sym
 
         @content = options[:content] || ""
         @date    = options[ :date ] ? ::Time.zone.parse( options[ :date ] ) : Time.zone.now
@@ -75,6 +81,7 @@ module Middleman
 
         app = ::Middleman::Application.new do
           config[ :mode ]              = :config
+          config[ :environment ] = env
           config[ :disable_sitemap ]   = true
           config[ :watcher_disable ]   = true
           config[ :exit_before_ready ] = true


### PR DESCRIPTION
As of https://github.com/middleman/middleman/pull/1293/files middleman splits the notion of `:mode` and `:environment`. This PR updates middleman-blog to also handle this distinction.

This allows generation of blogposts using config for a particular environment using the `--environment` flag. e.g:

`middleman article 'Awesome new post' --environment blog` would look for config within the `configure :blog do ... end` block.

The main gotcha I see is that this requires `Time.zone` to be set in config.rb also. I wonder though if that is related to one of the various other date-related issues:
https://github.com/middleman/middleman-blog/issues/238, https://github.com/middleman/middleman-blog/issues/191, https://github.com/middleman/middleman-blog/issues/143

Additionally, the `-e` alias is already used for editing on this project, while for middleman itself, and other extensions, this is used for environment specification. I've left out that alias for now.