### PR TITLE
Disable Travis CI email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,6 @@ env :
     - TEST=true
     # - CODECLIMATE_REPO_TOKEN=81787f7b1c3bfa937edadcafbc94f807bf5af5c1142c7b793f2d9969a271de1f
 
-# notifications :
-#   slack : middleman:JW9OvXmn1m3XrSERe8866nBR
+notifications:
+  email: false
+  # slack: middleman:JW9OvXmn1m3XrSERe8866nBR


### PR DESCRIPTION
The PR status indicator is enough; sending emails for every broken build is repetitive and unnecessary.