### PR TITLE
Use new (separate) metadata methods on resources

### DIFF
--- a/fixtures/default-template-app/config.rb
+++ b/fixtures/default-template-app/config.rb
@@ -29,7 +29,7 @@ helpers do
   end
 
   def link_to_with_active(title, url, class_name = 'active')
-    active_class = (current_resource == sitemap.find_resource_by_path(url)) ? class_name : ''
+    active_class = (current_resource == sitemap.by_path(url)) ? class_name : ''
     link_to(title, url, :class => active_class)
   end
 end

--- a/lib/middleman-blog/blog_article.rb
+++ b/lib/middleman-blog/blog_article.rb
@@ -53,7 +53,7 @@ module Middleman
 
         unless opts.has_key?( :layout )
 
-          opts[:layout] = metadata[:options][:layout]
+          opts[:layout] = options[:layout]
           opts[:layout] = blog_options.layout if opts[:layout].nil? || opts[:layout] == :_auto_layout
 
           # Convert to a string unless it's a boolean

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -145,7 +145,7 @@ module Middleman
 
             # Add extra parameters from the URL to the page metadata
             extra_data = params.except *%w(year month day title lang locale)
-            article.add_metadata page: extra_data unless extra_data.empty?
+            article.add_metadata_page extra_data unless extra_data.empty?
 
             # compute output path: substitute date parts to path pattern
             article.destination_path = template_path @permalink_template, article, extra_data
@@ -165,7 +165,7 @@ module Middleman
 
               # Add extra parameters from the URL to the page metadata
               extra_data = params.except *%w(year month day title lang locale)
-              article.add_metadata page: extra_data unless extra_data.empty?
+              article.add_metadata_page extra_data unless extra_data.empty?
 
               # The subdir path is the article path with the index file name
               # or file extension stripped off.
@@ -210,7 +210,7 @@ module Middleman
       ##
       def permalink_options(resource, extra={})
         # Allow any frontmatter data to be substituted into the permalink URL
-        params = resource.metadata[:page].slice *@permalink_template.variables.map(&:to_sym)
+        params = resource.page.slice *@permalink_template.variables.map(&:to_sym)
 
         params.each do |k, v|
           params[k] = safe_parameterize(v)
@@ -232,7 +232,8 @@ module Middleman
         resource.blog_controller = controller
 
         if !options.preserve_locale && (locale = resource.locale || resource.lang)
-          resource.add_metadata options: { lang: locale, locale: locale }, locals: { lang: locale, locale: locale }
+          resource.add_metadata_options(lang: locale, locale: locale)
+          resource.add_metadata_locals(lang: locale, locale: locale)
         end
 
         resource

--- a/lib/middleman-blog/blog_data.rb
+++ b/lib/middleman-blog/blog_data.rb
@@ -158,7 +158,7 @@ module Middleman
             # figure out the matching article for this subdirectory file
             article_path = @source_template.expand(params).to_s
 
-            if article = @app.sitemap.find_resource_by_path(article_path)
+            if article = @app.sitemap.by_path(article_path)
               # The article may not yet have been processed, so convert it here.
               article = convert_to_article(article)
               next unless publishable?(article)

--- a/lib/middleman-blog/calendar_pages.rb
+++ b/lib/middleman-blog/calendar_pages.rb
@@ -74,37 +74,37 @@ module Middleman
         Sitemap::ProxyResource.new(@sitemap, link(year), @year_template).tap do |p|
           # Add metadata in local variables so it's accessible to
           # later extensions
-          p.add_metadata locals: {
+          p.add_metadata_locals(
             'page_type' => 'year',
             'year' => year,
             'articles' => year_articles,
             'blog_controller' => @blog_controller
-          }
+          )
         end
       end
 
       def month_page_resource(year, month, month_articles)
         Sitemap::ProxyResource.new(@sitemap, link(year, month), @month_template).tap do |p|
-          p.add_metadata locals: {
+          p.add_metadata_locals(
             'page_type' => 'month',
             'year' => year,
             'month' => month,
             'articles' => month_articles,
             'blog_controller' => @blog_controller
-          }
+          )
         end
       end
 
       def day_page_resource(year, month, day, day_articles)
         Sitemap::ProxyResource.new(@sitemap, link(year, month, day), @day_template).tap do |p|
-          p.add_metadata locals: {
+          p.add_metadata_locals(
             'page_type' => 'day',
             'year' => year,
             'month' => month,
             'day' => day,
             'articles' => day_articles,
             'blog_controller' => @blog_controller
-          }
+          )
         end
       end
     end

--- a/lib/middleman-blog/custom_pages.rb
+++ b/lib/middleman-blog/custom_pages.rb
@@ -39,12 +39,12 @@ module Middleman
       def build_resource(path, value, articles)
         articles = articles.sort_by(&:date).reverse
         Sitemap::ProxyResource.new(@sitemap, path, @page_template).tap do |p|
-          p.add_metadata locals: {
+          p.add_metadata_locals(
             "page_type"       => property.to_s,
             property          => value,
             "articles"        => articles,
             "blog_controller" => @blog_controller
-          }
+          )
         end
       end
     end

--- a/lib/middleman-blog/helpers.rb
+++ b/lib/middleman-blog/helpers.rb
@@ -155,7 +155,7 @@ module Middleman
       private
 
       def build_url(path)
-        sitemap.find_resource_by_path(path).try(:url)
+        sitemap.by_path(path).try(:url)
       end
     end
   end

--- a/lib/middleman-blog/helpers.rb
+++ b/lib/middleman-blog/helpers.rb
@@ -28,7 +28,7 @@ module Middleman
       # @return [BlogExtension]
       def blog_controller(blog_name=nil)
         if !blog_name && current_resource
-          blog_name = current_resource.metadata[:page][:blog]
+          blog_name = current_resource.page[:blog]
 
           if !blog_name
             blog_controller = current_resource.blog_controller if current_resource.respond_to?(:blog_controller)
@@ -124,12 +124,12 @@ module Middleman
       # @param [Symbol, String] blog_name Optional name of the blog to use.
       # @return [Array<Middleman::Sitemap::Resource>]
       def page_articles(blog_name=nil)
-        meta = current_resource.metadata
+        locals = current_resource.locals
         limit = current_resource.data[:per_page]
 
         # "articles" local variable is populated by Calendar and Tag page generators
         # If it's not set then use the complete list of articles
-        articles = meta[:locals]["articles"] || blog(blog_name).articles
+        articles = locals["articles"] || blog(blog_name).articles
 
         limit ? articles.first(limit) : articles
       end

--- a/lib/middleman-blog/tag_pages.rb
+++ b/lib/middleman-blog/tag_pages.rb
@@ -72,12 +72,12 @@ module Middleman
           # tagname = articles.first.tags.detect { |article_tag| safe_parameterize(article_tag) == tag }
 
           # Add metadata in local variables so it's accessible to later extensions
-          p.add_metadata locals: {
+          p.add_metadata_locals(
             'page_type'       => 'tag',
             'tagname'         => tag,
             'articles'        => articles,
             'blog_controller' => @blog_controller
-          }
+          )
 
         end
 


### PR DESCRIPTION
(This came up while looking at https://gitlab.com/gitlab-com/www-gitlab-com/issues/1265. I assume you don't want to merge this until a new release for Middleman as a whole is happening.)

`Middleman::Sitemap::Resource#{metadata,add_metadata}` no longer exist. Instead there are:

1. `Middleman::Sitemap::Resource#{options,add_metadata_options}`
2. `Middleman::Sitemap::Resource#{locals,add_metadata_locals}`
3. `Middleman::Sitemap::Resource#{page,add_metadata_page}`

See https://github.com/middleman/middleman/pull/2219.