### PR TITLE
use %z instead of %Z

### DIFF
--- a/lib/middleman-blog/commands/article.tt
+++ b/lib/middleman-blog/commands/article.tt
@@ -1,7 +1,7 @@
 ---
 
 title: <%= @title %>
-date: <%= @date.strftime('%F %R %Z') %>
+date: <%= @date.strftime('%F %R %z') %>
 tags: <%= @tags.join(",") %>
 
 ---


### PR DESCRIPTION
see #212

The bug has once been fixed with ab91e6d but somehow revived with 1548d60.
