### PR TITLE
fix command middleman article: it generates incorrect YAML when the title contains characters that should be escaped

### DIFF
--- a/lib/middleman-blog/commands/article.tt
+++ b/lib/middleman-blog/commands/article.tt
@@ -1,6 +1,6 @@
 ---
 
-title: <%= @title %>
+title: "<%= %Q[#{@title}] %>"
 date: <%= @date.strftime('%F %R %z') %>
 tags: <%= @tags.join(",") %>
 


### PR DESCRIPTION
Closes #377