### PR TITLE
Remove official support for Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   test:
@@ -9,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5"]
+        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,13 @@ gem 'yard', '~> 0.9', require: false
 # Test tools
 gem 'aruba', '~> 1.0', require: false
 gem 'capybara', '~> 3', require: false
-gem 'cucumber', '~> 3.0', require: false
+gem 'cucumber', require: false
 gem 'rspec', '~> 3.0', require: false
 gem 'timecop', '~> 0.6', require: false
 
 # Optional dependencies, included for tests
 gem 'kramdown'
-gem 'nokogiri', RUBY_VERSION < '2.6' ? '~> 1.12.0' : '>= 0', require: false
+gem 'rack', '< 3'
 
 # Code Quality
 gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'timecop', '~> 0.6', require: false
 # Optional dependencies, included for tests
 gem 'kramdown'
 gem 'rack', '< 3'
+gem 'activesupport', RUBY_VERSION < '3.1' ? '< 7.1' : '>= 0'
 
 # Code Quality
 gem 'rubocop', require: false


### PR DESCRIPTION
In line with:
- https://github.com/middleman/middleman/pull/2738
- https://github.com/middleman/middleman-syntax/pull/89