### PR TITLE
Add specs to test permalink summary truncation

### DIFF
--- a/features/summary.feature
+++ b/features/summary.feature
@@ -1,5 +1,5 @@
 Feature: Article summary generation
-  Scenario: Article has no summary separator
+  Scenario: Article has standard summary separator
     Given the Server is running at "summary-app"
     When I go to "/index.html"
     Then I should see:
@@ -7,9 +7,20 @@ Feature: Article summary generation
       <p>Summary from article with separator.
       </p>
       """
-    Then I should not see "Extended part from article with separator."
+    And I should not see "Extended part from article with separator."
+    When I go to "/2011/01/01/article-with-standard-summary-separator.html"
+    Then I should see "Extended part from article with separator."
+    And I should not see "READMORE"
+    And I should not see "Summary from article with separator."
+
+  Scenario: Article has no summary separator
+    Given the Server is running at "summary-app"
+    When I go to "/index.html"
     Then I should see "<p>Summary from article with no separator.</p>"
     Then I should not see "Extended part from article with no separator."
+    When I go to "/2012/06/19/article-with-no-summary-separator.html"
+    And I should see "Summary from article with no separator."
+    Then I should see "Extended part from article with no separator."
 
   Scenario: Article has custom summary separator
     Given a fixture app "summary-app"
@@ -28,6 +39,10 @@ Feature: Article summary generation
       """
     Then I should not see "Extended part from article with custom separator."
     Then I should see "Extended part from article with separator."
+    When I go to "/2013/05/08/article-with-custom-separator.html"
+    And I should see "Extended part from article with custom separator."
+    Then I should not see "SPLIT_SUMMARY_BEFORE_THIS"
+    Then I should not see "Summary from article with custom separator."
 
   Scenario: Article has custom summary separator that's an HTML comment
     Given a fixture app "summary-app"
@@ -46,6 +61,10 @@ Feature: Article summary generation
       """
     Then I should not see "Extended part from article with HTML comment separator."
     Then I should see "Extended part from article with separator."
+    When I go to "/2016/05/21/article-with-comment-separator.html"
+    And I should see "Extended part from article with HTML comment separator."
+    Then I should not see "<!--more-->"
+    Then I should not see "Summary from article with HTML comment separator."
 
   Scenario: Using a custom summary generator
     Given a fixture app "summary-app"

--- a/fixtures/summary-app/source/layout.erb
+++ b/fixtures/summary-app/source/layout.erb
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <%= yield %>
+  </body>
+</html>


### PR DESCRIPTION
This is a PR to validate a bug in summary behavior. The behavior expected for summaries is as follows:

1. Truncation by length
    - `article.summary` is the first x number of characters.
    - `aritcle.body` has all content including the first x characters.
2. Separator such as `READMORE`
    - `article.summary` is everything before separator
    - `article.body` has all content AFTER separator
    - separator string has been stripped out

This PR adds some tests that shows when in scenario 2 using a separator: `article.body` only strips out the separator but leaves in the summary content.

As per documentation:
> The blogging extension looks for the string READMORE in your article body and shows only the content before this text on the homepage. On the permalink page, this data is then stripped out.

[Looking around](https://forum.middlemanapp.com/t/hot-to-get-article-body-without-the-summary-for-middleman-blog/2537), I think most people don't use the separator. Instead the preferred method seems to be to add another front matter field to use for summary.

I tried a quick fix at `Middleman::Blog::BlogArticle`
```diff
-        content.sub!(blog_options.summary_separator, '') unless opts[:keep_separator]
+        content = content.split(blog_options.summary_separator).last unless opts[:keep_separator]
```

But this chopped the rendered html document in half instead. 

I'm tossing this PR up in the hopes someone more knowledgable can present a fix. 

I think it needs to be done further up the chain. Before the markdown content is rendered. Because middleman-core handles markdown rendering in a separate repo I'm not sure it's wise to directly edit that file for the edge case of blogging. Maybe monkeypatch that class to strip the summary content before rendering? If we monkeypatched into the content before rendering, we might be able to remove Nokogiri dependency. Since then we'd have access to the text from the markdown file before it gets rendered into html.