### PR TITLE
Only set ActiveSupport `to_time_preserves_timezone` on 8.0 and older

### DIFF
--- a/lib/middleman-blog/extension.rb
+++ b/lib/middleman-blog/extension.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/time/zones'
+require 'active_support/version'
 require 'middleman-blog/blog_data'
 require 'middleman-blog/blog_article'
 require 'middleman-blog/helpers'
@@ -125,7 +126,11 @@ module Middleman
       @app.ignore(options.day_template) if options.day_template
       @app.ignore options.tag_template if options.tag_template
 
-      ActiveSupport.to_time_preserves_timezone = :zone
+      # Receiver zone support is the only supported method in 8.1+, and the setting triggers a
+      # deprecation warning in 8.2, so only needed on older versions.
+      if ActiveSupport.version < Gem::Version.new('8.1')
+        ActiveSupport.to_time_preserves_timezone = :zone
+      end
 
       # Make sure ActiveSupport's TimeZone stuff has something to work with,
       # allowing people to set their desired time zone via Time.zone or


### PR DESCRIPTION
In ActiveSupport 8.1, the `to_time_preserves_timezone` setting [was deprecated](https://github.com/rails/rails/commit/c79dc282d687cff1c5dc81e19d27257dca5e6a80) and no longer has any effect on the implementation of `to_time`, however it logs a deprecation warning when the extension is initialised:

    DEPRECATION WARNING: `config.active_support.to_time_preserves_timezone`
    is deprecated and will be removed in Rails 8.2 (called from
    Middleman::BlogExtension#after_configuration at ...)

From 8.2, the setting will be removed entirely so to silence the warning and ensure future compatibility, only set the mode on older versions of ActiveSupport where it's needed.

Once middleman-core requires 8.1 or higher, this can be safely removed again.